### PR TITLE
Partial/authentication/permission framework ph3

### DIFF
--- a/__tests__/lib/permissions.test.ts
+++ b/__tests__/lib/permissions.test.ts
@@ -1,0 +1,67 @@
+import { hasPermission, Permissions } from "@/lib/permissions";
+import { ROLES_OBJ } from "@/lib/roles";
+
+describe("Permission System", () => {
+  describe("Permission Constants", () => {
+    it("should define all required permissions", () => {
+      expect(Permissions).toBeDefined();
+      expect(Permissions.VIEW_DEVICES).toBeDefined();
+      expect(Permissions.CONTROL_DEVICES).toBeDefined();
+      expect(Permissions.VIEW_USAGE_DATA).toBeDefined();
+      expect(Permissions.MANAGE_DEVICES).toBeDefined();
+    });
+
+    it("should have unique permission values", () => {
+      const permissionValues = Object.values(Permissions);
+      const uniqueValues = new Set(permissionValues);
+      expect(uniqueValues.size).toBe(permissionValues.length);
+    });
+  });
+
+  describe("Role-Permission Mapping; Testing func hasPermission", () => {
+    it("should grant appropriate permissions to ADMIN role", () => {
+      expect(hasPermission(ROLES_OBJ.ADMIN, Permissions.VIEW_DEVICES)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.ADMIN, Permissions.CONTROL_DEVICES)).toBe(
+        false,
+      );
+      expect(hasPermission(ROLES_OBJ.ADMIN, Permissions.VIEW_USAGE_DATA)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.ADMIN, Permissions.MANAGE_DEVICES)).toBe(
+        true,
+      );
+    });
+
+    it("should grant appropriate permissions to MEMBER role", () => {
+      expect(hasPermission(ROLES_OBJ.MEMBER, Permissions.VIEW_DEVICES)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.MEMBER, Permissions.CONTROL_DEVICES)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.MEMBER, Permissions.VIEW_USAGE_DATA)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.MEMBER, Permissions.MANAGE_DEVICES)).toBe(
+        false,
+      );
+    });
+
+    it("should grant appropriate permissions to GUEST role", () => {
+      expect(hasPermission(ROLES_OBJ.GUEST, Permissions.VIEW_DEVICES)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.GUEST, Permissions.CONTROL_DEVICES)).toBe(
+        false,
+      );
+      expect(hasPermission(ROLES_OBJ.GUEST, Permissions.VIEW_USAGE_DATA)).toBe(
+        true,
+      );
+      expect(hasPermission(ROLES_OBJ.GUEST, Permissions.MANAGE_DEVICES)).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -47,6 +47,12 @@ describe("Authentication Middleware", () => {
         "_next/image",
         "favicon.ico",
         "public",
+        "api/auth/signin",
+        "api/auth/callback",
+        "api/auth/signout",
+        "api/auth/session",
+        "api/auth/csrf",
+        "api/auth/providers",
       ];
 
       requiredExclusions.forEach((exclusion) => {

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,133 @@
+import { middleware, config } from "@/middleware";
+import { ROLES_OBJ } from "@/lib/roles";
+import { auth } from "@/app/auth";
+
+// Mock next/server
+jest.mock("next/server", () => {
+  const NextResponse = jest.fn().mockImplementation((body, init) => ({
+    status: init?.status || 200,
+    headers: new Map(),
+  }));
+
+  return {
+    NextResponse: Object.assign(NextResponse, {
+      redirect: jest.fn().mockImplementation((url) => ({
+        status: 307,
+        headers: new Map([["Location", url.pathname]]),
+      })),
+    }),
+  };
+});
+
+// Mock auth module
+jest.mock("@/app/auth", () => ({
+  auth: jest.fn(),
+}));
+
+const mockAuth = auth as jest.Mock;
+
+describe("Authentication Middleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Middleware Configuration", () => {
+    it("should have a matcher configuration", () => {
+      expect(config).toBeDefined();
+      expect(config.matcher).toBeDefined();
+      expect(Array.isArray(config.matcher)).toBe(true);
+    });
+
+    it("should properly configure path exclusions", () => {
+      const matcher = config.matcher[0];
+
+      // Verify that the matcher pattern contains all necessary exclusions
+      const requiredExclusions = [
+        "_next/static",
+        "_next/image",
+        "favicon.ico",
+        "public",
+      ];
+
+      requiredExclusions.forEach((exclusion) => {
+        expect(matcher).toContain(exclusion);
+      });
+    });
+
+    it("should include relevant paths in middleware", () => {
+      const matcher = config.matcher[0];
+      const includedPaths = [
+        "/",
+        "/dashboard",
+        "/admin",
+        "/admin/settings",
+        "/auth/signin",
+        "/auth/error",
+      ];
+
+      // These paths should match the middleware pattern
+      includedPaths.forEach((path) => {
+        expect(path).toMatch(new RegExp(matcher));
+      });
+    });
+  });
+
+  const createMockRequest = (pathname: string) => ({
+    nextUrl: { pathname },
+    url: `http://localhost:3000${pathname}`,
+  });
+
+  it("should allow access to public routes without authentication", async () => {
+    const mockReq = createMockRequest("/auth/signin");
+    const response = await middleware(mockReq as any);
+    expect(response).toBeUndefined();
+  });
+
+  it("should redirect unauthenticated users to signin for protected routes", async () => {
+    mockAuth.mockResolvedValueOnce({ user: null });
+    const mockReq = createMockRequest("/dashboard");
+    const response = await middleware(mockReq as any);
+
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("Location")).toBe("/auth/signin");
+  });
+
+  it("should allow authenticated users to access protected routes", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { role: ROLES_OBJ.MEMBER },
+    });
+
+    const mockReq = createMockRequest("/dashboard");
+    const response = await middleware(mockReq as any);
+    expect(response).toBeUndefined();
+  });
+
+  it("should deny access to admin routes for non-admin users", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { role: ROLES_OBJ.MEMBER },
+    });
+
+    const mockReq = createMockRequest("/admin/settings");
+    const response = await middleware(mockReq as any);
+
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(403);
+  });
+
+  it("should allow admins to access admin routes", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { role: ROLES_OBJ.ADMIN },
+    });
+
+    const mockReq = createMockRequest("/admin/settings");
+    const response = await middleware(mockReq as any);
+    expect(response).toBeUndefined();
+  });
+
+  it("should allow access to error pages", async () => {
+    const mockReq = createMockRequest("/auth/error");
+    const response = await middleware(mockReq as any);
+    expect(response).toBeUndefined();
+  });
+});

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,43 @@
+import { Role, ROLES_OBJ } from "./roles";
+
+/**
+ * Permission object with constant values
+ */
+export const Permissions = {
+  VIEW_DEVICES: "view_devices",
+  CONTROL_DEVICES: "control_devices",
+  VIEW_USAGE_DATA: "view_usage_data",
+  MANAGE_DEVICES: "manage_devices",
+} as const;
+
+/**
+ * Permission type derived from the Permission object values
+ */
+export type Permission = (typeof Permissions)[keyof typeof Permissions];
+
+/**
+ * Role to Permission mapping
+ */
+const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
+  [ROLES_OBJ.ADMIN]: [
+    Permissions.VIEW_DEVICES,
+    Permissions.VIEW_USAGE_DATA,
+    Permissions.MANAGE_DEVICES,
+  ],
+  [ROLES_OBJ.MEMBER]: [
+    Permissions.VIEW_DEVICES,
+    Permissions.CONTROL_DEVICES,
+    Permissions.VIEW_USAGE_DATA,
+  ],
+  [ROLES_OBJ.GUEST]: [Permissions.VIEW_DEVICES, Permissions.VIEW_USAGE_DATA],
+};
+
+/**
+ * Checks if a role has a specific permission
+ * @param role The role to check
+ * @param permission The permission to check for
+ * @returns True if the role has the permission, false otherwise
+ */
+export function hasPermission(role: Role, permission: Permission): boolean {
+  return ROLE_PERMISSIONS[role].includes(permission);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,7 +47,13 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - public (public files)
+     * - api/auth/signin
+     * - api/auth/callback
+     * - api/auth/signout
+     * - api/auth/session
+     * - api/auth/csrf
+     * - api/auth/providers
      */
-    "/((?!_next/static|_next/image|favicon.ico|public).*)",
+    "/((?!_next/static|_next/image|favicon.ico|public|api/auth/signin|api/auth/callback|api/auth/signout|api/auth/session|api/auth/csrf|api/auth/providers).*)",
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ROLES_OBJ } from "@/lib/roles";
+import { auth } from "@/app/auth";
+
+// Define public routes that don't require authentication
+const PUBLIC_PATHS = ["/auth/signin", "/auth/error"];
+
+/**
+ * Middleware function to handle authentication and authorization
+ * @param request The incoming request
+ * @returns NextResponse if authentication/authorization fails, undefined if allowed
+ */
+export async function middleware(request: NextRequest) {
+  // Get the pathname from the URL
+  const { pathname } = request.nextUrl;
+
+  // Allow access to public routes
+  if (PUBLIC_PATHS.includes(pathname)) {
+    return undefined;
+  }
+
+  // Get the session
+  const session = await auth();
+
+  // If no session, redirect to signin
+  if (!session?.user) {
+    return NextResponse.redirect(new URL("/auth/signin", request.url));
+  }
+
+  // Check admin routes
+  if (pathname.startsWith("/admin")) {
+    if (session.user.role !== ROLES_OBJ.ADMIN) {
+      return new NextResponse(null, { status: 403 });
+    }
+  }
+
+  // Allow access to protected routes for authenticated users
+  return undefined;
+}
+
+// Configure middleware matcher
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public (public files)
+     */
+    "/((?!_next/static|_next/image|favicon.ico|public).*)",
+  ],
+};


### PR DESCRIPTION
# Changes
## Phase 3: Permission Framework
### 3.1 Permission Definition
- Write tests for permission constants and role mappings
- Define permission constants for different actions
- Create permission mapping to roles
- Implement and test permission checking utilities
### 3.2 Authorization Middleware
- Write tests for middleware functionality
- Create middleware to check user authentication status
- Implement role-based route protection
- Test and implement unauthorized access handling
## Phase 4: Role-Specific Permissions(Implemented along phase-3)
### 4.1 Member Permissions Implementation
- Write tests for member-specific permissions
- Implement view devices permission
- Implement turn devices on/off permission
- Implement view usage data permission
### 4.2 Admin Permissions Implementation
- Write tests for admin-specific permissions
- Implement add/delete devices permission
### 4.3 Guest Permissions Implementation
- Write tests for guest-specific permissions
- Implement view-only permissions for devices and usage data