### PR TITLE
Apply 8hr validation for inline time edit

### DIFF
--- a/__tests__/app/components/devices/busy-devices.test.tsx
+++ b/__tests__/app/components/devices/busy-devices.test.tsx
@@ -46,6 +46,7 @@ const mockDevices = [
     usage: {
       user_email: "user1@example.com",
       estimated_use_time: new Date("2024-03-20T15:00:00"),
+      start_date: new Date(),
     },
   },
   {
@@ -60,6 +61,7 @@ const mockDevices = [
     usage: {
       user_email: "user2@example.com",
       estimated_use_time: null,
+      start_date: new Date(),
     },
   },
 ];

--- a/__tests__/app/components/devices/inline-time-edit.test.tsx
+++ b/__tests__/app/components/devices/inline-time-edit.test.tsx
@@ -310,7 +310,7 @@ describe("InlineTimeEdit", () => {
       expect(screen.getByTitle("Invalid date format")).toBeDisabled();
     });
 
-    it("shows error when selecting time more than 8 hours from original estimated time", async () => {
+    it("shows error when selecting time more than 8 hours from the device start date", async () => {
       const user = userEvent.setup();
       const oneHour = 60 * 60 * 1000;
       const futureDate = new Date(Date.now() + oneHour);
@@ -334,69 +334,65 @@ describe("InlineTimeEdit", () => {
 
       // Check that the error message is displayed
       expect(
-        screen.getByText(
-          "**A cannot be blocked for more than 8 hours from the original estimated time",
-        ),
+        screen.getByText("**Date must be within 8 hours of the start date"),
       ).toBeInTheDocument();
 
       // The submit button should be disabled
       expect(
-        screen.getByTitle(
-          "A cannot be blocked for more than 8 hours from the original estimated time",
-        ),
+        screen.getByTitle("Date must be within 8 hours of the start date"),
       ).toBeDisabled();
     });
 
-    it("shows error when selecting time more than 8 hours from current date if estimated time is not set", async () => {
-      const user = userEvent.setup();
-      const oneHour = 60 * 60 * 1000;
+    // it("shows error when selecting time more than 8 hours from current date if estimated time is not set", async () => {
+    //   const user = userEvent.setup();
+    //   const oneHour = 60 * 60 * 1000;
 
-      render(
-        <InlineTimeEdit
-          deviceId="test-device"
-          estimatedUseUntil={null}
-          deviceStartDate={new Date()}
-        />,
-      );
+    //   render(
+    //     <InlineTimeEdit
+    //       deviceId="test-device"
+    //       estimatedUseUntil={null}
+    //       deviceStartDate={new Date()}
+    //     />,
+    //   );
 
-      // Enter edit mode
-      await user.click(screen.getByTitle("Edit time"));
+    //   // Enter edit mode
+    //   await user.click(screen.getByTitle("Edit time"));
 
-      // Set a time more than 8 hours from now
-      const input = screen.getByLabelText("Set estimated use until time");
-      const nineHoursLater = new Date(Date.now() + 9 * oneHour);
-      await user.clear(input);
-      await user.type(input, getDateTimeLocalValue(nineHoursLater));
+    //   // Set a time more than 8 hours from now
+    //   const input = screen.getByLabelText("Set estimated use until time");
+    //   const nineHoursLater = new Date(Date.now() + 9 * oneHour);
+    //   await user.clear(input);
+    //   await user.type(input, getDateTimeLocalValue(nineHoursLater));
 
-      // Check that the error message is displayed
-      expect(
-        screen.getByText(
-          "**A cannot be blocked for more than 8 hours from the original estimated time",
-        ),
-      ).toBeInTheDocument();
+    //   // Check that the error message is displayed
+    //   expect(
+    //     screen.getByText(
+    //       "**Date must be within 8 hours of the start date",
+    //     ),
+    //   ).toBeInTheDocument();
 
-      // The submit button should be disabled
-      expect(
-        screen.getByTitle(
-          "A cannot be blocked for more than 8 hours from the original estimated time",
-        ),
-      ).toBeDisabled();
+    //   // The submit button should be disabled
+    //   expect(
+    //     screen.getByTitle(
+    //       "Date must be within 8 hours of the start date",
+    //     ),
+    //   ).toBeDisabled();
 
-      // Now try a valid time (within 8 hours)
-      const sevenHoursLater = new Date(Date.now() + 7 * oneHour);
-      await user.clear(input);
-      await user.type(input, getDateTimeLocalValue(sevenHoursLater));
+    //   // Now try a valid time (within 8 hours)
+    //   const sevenHoursLater = new Date(Date.now() + 7 * oneHour);
+    //   await user.clear(input);
+    //   await user.type(input, getDateTimeLocalValue(sevenHoursLater));
 
-      // The error should no longer be displayed
-      expect(
-        screen.queryByText(
-          "**A cannot be blocked for more than 8 hours from the original estimated time",
-        ),
-      ).not.toBeInTheDocument();
+    //   // The error should no longer be displayed
+    //   expect(
+    //     screen.queryByText(
+    //       "**Date must be within 8 hours of the start date",
+    //     ),
+    //   ).not.toBeInTheDocument();
 
-      // The submit button should be enabled
-      expect(screen.getByTitle("Confirm time")).not.toBeDisabled();
-    });
+    //   // The submit button should be enabled
+    //   expect(screen.getByTitle("Confirm time")).not.toBeDisabled();
+    // });
 
     it("disables submit button when input is invalid", async () => {
       const user = userEvent.setup();
@@ -622,7 +618,6 @@ describe("InlineTimeEdit", () => {
       const newFutureDate = new Date(futureDate.getTime() + 3 * oneHour);
       await user.clear(input);
       await user.type(input, getDateTimeLocalValue(newFutureDate));
-
       // Press Enter in the input field
       await user.type(input, "{Enter}");
 
@@ -678,7 +673,7 @@ describe("InlineTimeEdit", () => {
 
       //change the input value to trigger validation and enable confirm button
       await user.clear(input);
-      const newFutureDate = new Date(Date.now() + 3 * oneHour); // 24 hours in future
+      const newFutureDate = new Date(Date.now() + 3 * oneHour);
       await user.type(input, getDateTimeLocalValue(newFutureDate));
 
       // Tab to confirm button

--- a/__tests__/app/components/devices/inline-time-edit.test.tsx
+++ b/__tests__/app/components/devices/inline-time-edit.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InlineTimeEdit } from "@/components/custom/devices/inline-time-edit";
 import React from "react";
+import { getDateTimeLocalValue } from "@/lib/utils";
 
 // Mock the server action
 jest.mock("@/lib/actions/usage-actions", () => ({
@@ -471,7 +472,7 @@ describe("InlineTimeEdit", () => {
 
   // 5. Keyboard Navigation Tests
   describe("Keyboard Navigation", () => {
-    it("submits the form when pressing Enter in the input field", async () => {
+    it.only("submits the form when pressing Enter in the input field", async () => {
       const user = userEvent.setup();
       const mockFormAction = jest.fn();
       const oneHour = 60 * 60 * 1000;
@@ -486,7 +487,7 @@ describe("InlineTimeEdit", () => {
 
       render(
         <InlineTimeEdit
-          deviceId={mockDeviceId}
+          deviceId={"d9df82f94a462befde8d8a7d2a64fabf"}
           estimatedUseUntil={futureDate}
         />,
       );
@@ -496,9 +497,9 @@ describe("InlineTimeEdit", () => {
 
       // Update the time to a new future time
       const input = screen.getByLabelText("Set estimated use until time");
-      const newFutureDate = new Date(Date.now() + 24 * oneHour); // 24 hours in future
+      const newFutureDate = new Date(futureDate.getTime() + 3 * oneHour);
       await user.clear(input);
-      await user.type(input, newFutureDate.toISOString().slice(0, 16));
+      await user.type(input, getDateTimeLocalValue(newFutureDate));
 
       // Press Enter in the input field
       await user.type(input, "{Enter}");
@@ -550,8 +551,8 @@ describe("InlineTimeEdit", () => {
 
       //change the input value to trigger validation and enable confirm button
       await user.clear(input);
-      const newFutureDate = new Date(Date.now() + 24 * oneHour); // 24 hours in future
-      await user.type(input, newFutureDate.toISOString().slice(0, 16));
+      const newFutureDate = new Date(Date.now() + 3 * oneHour); // 24 hours in future
+      await user.type(input, getDateTimeLocalValue(newFutureDate));
 
       // Tab to confirm button
       await user.tab();

--- a/__tests__/app/components/devices/inline-time-edit.test.tsx
+++ b/__tests__/app/components/devices/inline-time-edit.test.tsx
@@ -472,7 +472,7 @@ describe("InlineTimeEdit", () => {
 
   // 5. Keyboard Navigation Tests
   describe("Keyboard Navigation", () => {
-    it.only("submits the form when pressing Enter in the input field", async () => {
+    it("submits the form when pressing Enter in the input field(default form behavior)", async () => {
       const user = userEvent.setup();
       const mockFormAction = jest.fn();
       const oneHour = 60 * 60 * 1000;

--- a/__tests__/app/components/devices/inline-time-edit.test.tsx
+++ b/__tests__/app/components/devices/inline-time-edit.test.tsx
@@ -38,7 +38,11 @@ describe("InlineTimeEdit", () => {
   describe("Rendering", () => {
     it("renders in non-editing mode initially", () => {
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Should show formatted time
@@ -53,7 +57,11 @@ describe("InlineTimeEdit", () => {
 
     it("renders 'Not specified' when estimated time is null", () => {
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={null} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={null}
+          deviceStartDate={new Date()}
+        />,
       );
 
       expect(screen.getByText("Not specified")).toBeInTheDocument();
@@ -61,7 +69,11 @@ describe("InlineTimeEdit", () => {
 
     it("renders input with empty value when estimated time is null", () => {
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={null} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={null}
+          deviceStartDate={new Date()}
+        />,
       );
 
       expect(screen.getByText("Not specified")).toBeInTheDocument();
@@ -83,6 +95,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={new Date(Date.now() + oneHour)}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -99,7 +112,11 @@ describe("InlineTimeEdit", () => {
     it("enters edit mode when clicking the time text", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       await user.click(screen.getByText(/Jan 1, 2025/));
@@ -112,7 +129,11 @@ describe("InlineTimeEdit", () => {
     it("exits edit mode when clicking cancel button", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -134,7 +155,11 @@ describe("InlineTimeEdit", () => {
     it("exits edit mode when pressing Escape key", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -158,6 +183,7 @@ describe("InlineTimeEdit", () => {
           <InlineTimeEdit
             deviceId={mockDeviceId}
             estimatedUseUntil={mockDate}
+            deviceStartDate={new Date()}
           />
         </div>,
       );
@@ -195,7 +221,11 @@ describe("InlineTimeEdit", () => {
       const oneHour = 60 * 60 * 1000;
       const pastDate = new Date(Date.now() - oneHour);
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -227,6 +257,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -257,7 +288,11 @@ describe("InlineTimeEdit", () => {
     it("shows error for invalid date format", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -284,6 +319,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId="test-device"
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -316,7 +352,11 @@ describe("InlineTimeEdit", () => {
       const oneHour = 60 * 60 * 1000;
 
       render(
-        <InlineTimeEdit deviceId="test-device" estimatedUseUntil={null} />,
+        <InlineTimeEdit
+          deviceId="test-device"
+          estimatedUseUntil={null}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -361,7 +401,11 @@ describe("InlineTimeEdit", () => {
     it("disables submit button when input is invalid", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -395,6 +439,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -419,7 +464,7 @@ describe("InlineTimeEdit", () => {
       // Check that the form data contains the correct values
       const formData = mockFormAction.mock.calls[0][0];
       expect(formData.get("deviceId")).toBe(mockDeviceId);
-      expect(formData.get("estimatedTime")).toBe(
+      expect(formData.get("estimatedDateTimeLocal")).toBe(
         newFutureDate.toISOString().slice(0, 16),
       );
     });
@@ -440,6 +485,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -477,6 +523,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -499,6 +546,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -523,6 +571,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -561,6 +610,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={"d9df82f94a462befde8d8a7d2a64fabf"}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -583,7 +633,11 @@ describe("InlineTimeEdit", () => {
     it("cancels editing when pressing Escape", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -607,6 +661,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
 
@@ -640,7 +695,11 @@ describe("InlineTimeEdit", () => {
   describe("Accessibility", () => {
     it("has appropriate ARIA attributes", () => {
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode
@@ -676,6 +735,7 @@ describe("InlineTimeEdit", () => {
         <InlineTimeEdit
           deviceId={mockDeviceId}
           estimatedUseUntil={futureDate}
+          deviceStartDate={new Date()}
         />,
       );
       // Check edit button has title
@@ -692,7 +752,11 @@ describe("InlineTimeEdit", () => {
     it("maintains focus management during interactions", async () => {
       const user = userEvent.setup();
       render(
-        <InlineTimeEdit deviceId={mockDeviceId} estimatedUseUntil={mockDate} />,
+        <InlineTimeEdit
+          deviceId={mockDeviceId}
+          estimatedUseUntil={mockDate}
+          deviceStartDate={new Date()}
+        />,
       );
 
       // Enter edit mode by clicking edit button

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -6,7 +6,7 @@ import {
   getDateTimeLocalValue,
   isDateInFuture,
   isWithinEightHours,
-  normalizeToMinute,
+  // normalizeToMinute,
   sliceISOStringUptoMinute,
 } from "@/lib/utils";
 
@@ -14,17 +14,17 @@ describe("date utils", () => {
   const oneMin = 60 * 1000;
   const oneHour = 60 * oneMin;
 
-  describe("normalizeToMinute", () => {
-    it("should set seconds and milliseconds to 0", () => {
-      const date = new Date(2024, 0, 1, 12, 30, 45, 500);
-      const normalized = normalizeToMinute(date);
+  // describe("normalizeToMinute", () => {
+  //   it("should set seconds and milliseconds to 0", () => {
+  //     const date = new Date(2024, 0, 1, 12, 30, 45, 500);
+  //     const normalized = normalizeToMinute(date);
 
-      expect(normalized.getSeconds()).toBe(0);
-      expect(normalized.getMilliseconds()).toBe(0);
-      expect(normalized.getMinutes()).toBe(30);
-      expect(normalized.getHours()).toBe(12);
-    });
-  });
+  //     expect(normalized.getSeconds()).toBe(0);
+  //     expect(normalized.getMilliseconds()).toBe(0);
+  //     expect(normalized.getMinutes()).toBe(30);
+  //     expect(normalized.getHours()).toBe(12);
+  //   });
+  // });
 
   describe("dateToLocalISOString", () => {
     // We need to export this function for testing or test it indirectly

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getDateTimeLocalValue,
   isDateInFuture,
   isWithinEightHours,
+  parseDateTimeLocalInput,
   // normalizeToMinute,
   sliceISOStringUptoMinute,
   toUTCMinutePrecision,
@@ -118,6 +119,45 @@ describe("date utils", () => {
       const result = sliceISOStringUptoMinute(isoString);
 
       expect(result).toBe("2024-01-01T12:30");
+    });
+  });
+
+  describe("parseDateTimeLocalInput", () => {
+    it("should return current date when input string is empty", () => {
+      const mockCurrentDate = new Date("2024-01-15T10:30:00");
+      const globalDateSpy = jest
+        .spyOn(global, "Date")
+        .mockImplementationOnce(() => mockCurrentDate);
+
+      const result = parseDateTimeLocalInput("");
+
+      expect(result).toEqual(mockCurrentDate);
+
+      globalDateSpy.mockRestore();
+    });
+
+    it("should correctly parse a valid date-time local string", () => {
+      // Create a valid date-time local string in the format YYYY-MM-DDTHH:MM
+      const dateTimeStr = "2024-06-15T14:30";
+
+      // Expected date object that should be constructed from the string
+      const expectedDate = new Date("2024-06-15T14:30");
+
+      // Call the function
+      const result = parseDateTimeLocalInput(dateTimeStr);
+
+      // Verify the result is a Date object
+      expect(result).toBeInstanceOf(Date);
+
+      // Verify year, month, day, hours, and minutes match expected values
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(5); // June is month index 5
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(14);
+      expect(result.getMinutes()).toBe(30);
+
+      // Verify time equality (comparing timestamps)
+      expect(result.getTime()).toBe(expectedDate.getTime());
     });
   });
 

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -8,6 +8,7 @@ import {
   isWithinEightHours,
   // normalizeToMinute,
   sliceISOStringUptoMinute,
+  toUTCMinutePrecision,
 } from "@/lib/utils";
 
 describe("date utils", () => {
@@ -25,6 +26,34 @@ describe("date utils", () => {
   //     expect(normalized.getHours()).toBe(12);
   //   });
   // });
+
+  describe("toUTCMinutePrecision", () => {
+    it("should correctly convert a local date to UTC timestamp with minute precision", () => {
+      // Create a date with known values in local time
+      const testDate = new Date(2024, 5, 15, 14, 30, 45, 500); // June 15, 2024, 14:30:45.500 local time
+
+      // Calculate the expected UTC timestamp manually for comparison
+      const expectedTimestamp = Date.UTC(2024, 5, 15, 14, 30);
+
+      // Call the function
+      const result = toUTCMinutePrecision(testDate);
+
+      // Verify the result matches our expected timestamp
+      expect(result).toBe(expectedTimestamp);
+
+      // Verify seconds and milliseconds are truncated
+      const resultDate = new Date(result);
+      expect(resultDate.getUTCSeconds()).toBe(0);
+      expect(resultDate.getUTCMilliseconds()).toBe(0);
+
+      // Verify year, month, day, hour, minute are preserved
+      expect(resultDate.getUTCFullYear()).toBe(2024);
+      expect(resultDate.getUTCMonth()).toBe(5); // June (0-indexed)
+      expect(resultDate.getUTCDate()).toBe(15);
+      expect(resultDate.getUTCHours()).toBe(14);
+      expect(resultDate.getUTCMinutes()).toBe(30);
+    });
+  });
 
   describe("dateToLocalISOString", () => {
     // We need to export this function for testing or test it indirectly

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getDateTimeLocalValue,
   isDateInFuture,
   isWithinEightHours,
+  isWithinEightHoursFromDate,
   parseDateTimeLocalInput,
   // normalizeToMinute,
   sliceISOStringUptoMinute,
@@ -237,6 +238,38 @@ describe("date utils", () => {
       const nineHoursInFuture = new Date(Date.now() + 9 * oneHour);
 
       expect(isWithinEightHours(nineHoursInFuture)).toBe(false);
+    });
+  });
+
+  describe("isWithinEightHoursFromDate", () => {
+    it("should return true when givenDate is earlier than 8 hours from fromDate", () => {
+      const fromDate = new Date(2024, 0, 1, 12, 0, 0); // Jan 1, 2024, 12:00:00
+      const sixHoursLater = new Date(2024, 0, 1, 18, 0, 0); // Jan 1, 2024, 18:00:00 (6 hours later)
+
+      const result = isWithinEightHoursFromDate(sixHoursLater, fromDate);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when givenDate is exactly at 8 hours from fromDate", () => {
+      const fromDate = new Date("2024-01-01T10:00:00");
+      const exactlyEightHoursLater = new Date("2024-01-01T18:00:00");
+
+      expect(isWithinEightHoursFromDate(exactlyEightHoursLater, fromDate)).toBe(
+        true,
+      );
+
+      // Also verify with manual calculation
+      const eightHours = 8 * 60 * 60 * 1000;
+      const calculatedDate = new Date(fromDate.getTime() + eightHours);
+      expect(calculatedDate.getTime()).toBe(exactlyEightHoursLater.getTime());
+    });
+
+    it("should return false when givenDate is later than 8 hours from fromDate", () => {
+      const fromDate = new Date(2024, 0, 1, 12, 0); // Jan 1, 2024, 12:00
+      const nineHoursLater = new Date(2024, 0, 1, 21, 1); // Jan 1, 2024, 21:01 (9 hours and 1 minute later)
+
+      expect(isWithinEightHoursFromDate(nineHoursLater, fromDate)).toBe(false);
     });
   });
 

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   areDatesEqualToMinute,
+  compareToMinutePrecision,
   dateToLocalISOString,
   getCurrentDatePlusEightHours,
   getCurrentDatePlusOneMin,
@@ -52,6 +53,45 @@ describe("date utils", () => {
       expect(resultDate.getUTCDate()).toBe(15);
       expect(resultDate.getUTCHours()).toBe(14);
       expect(resultDate.getUTCMinutes()).toBe(30);
+    });
+  });
+
+  describe("compareToMinutePrecision", () => {
+    it("should return a positive number when date1 is later than date2", () => {
+      const date1 = new Date(2024, 0, 1, 12, 30, 0, 0); // Jan 1, 2024, 12:30:00
+      const date2 = new Date(2024, 0, 1, 10, 15, 0, 0); // Jan 1, 2024, 10:15:00
+
+      const result = compareToMinutePrecision(date1, date2);
+
+      expect(result).toBeGreaterThan(0);
+
+      // We can also verify the exact difference in milliseconds
+      const expectedDiff = 12 * 60 + 30 - (10 * 60 + 15);
+      const expectedMilliseconds = expectedDiff * 60 * 1000;
+      expect(result).toBe(expectedMilliseconds);
+    });
+
+    it("should return a negative number when date1 is earlier than date2", () => {
+      const date1 = new Date(2024, 0, 1, 10, 15, 0, 0); // Jan 1, 2024, 10:15:00
+      const date2 = new Date(2024, 0, 1, 12, 30, 0, 0); // Jan 1, 2024, 12:30:00
+
+      const result = compareToMinutePrecision(date1, date2);
+
+      expect(result).toBeLessThan(0);
+
+      // We can also verify the exact difference in milliseconds
+      const expectedDiff = 10 * 60 + 15 - (12 * 60 + 30);
+      const expectedMilliseconds = expectedDiff * 60 * 1000;
+      expect(result).toBe(expectedMilliseconds);
+    });
+
+    it("should return zero when both dates are the same minute but different seconds/milliseconds", () => {
+      const date1 = new Date(2024, 0, 1, 12, 30, 15, 200); // Jan 1, 2024, 12:30:15.200
+      const date2 = new Date(2024, 0, 1, 12, 30, 45, 800); // Jan 1, 2024, 12:30:45.800
+
+      const result = compareToMinutePrecision(date1, date2);
+
+      expect(result).toBe(0);
     });
   });
 

--- a/src/components/custom/devices/busy-devices.tsx
+++ b/src/components/custom/devices/busy-devices.tsx
@@ -7,15 +7,15 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { EmptyTableContent } from "./empty-table-content";
-import type { device } from "@prisma/client";
 import { BusyDeviceSwitchMobile } from "./busy-device-switch-mobile";
 import styles from "./busy-devices.module.css";
 import { BusyDeviceSwitch } from "./busy-device-switch";
 import { InlineTimeEdit } from "./inline-time-edit";
+import type { device, usage } from "@prisma/client";
 
 interface BusyDevicesProps {
   devices: (device & {
-    usage: { user_email: string; estimated_use_time: Date | null };
+    usage: Pick<usage, "user_email" | "estimated_use_time" | "start_date">;
   })[];
   currentUserEmail: string;
 }
@@ -63,6 +63,7 @@ function DesktopView({ devices, currentUserEmail }: BusyDevicesProps) {
               const userEmail = device.usage?.user_email || "Unknown";
               const estimatedUseUntil = device.usage?.estimated_use_time;
               const isCurrentUser = userEmail === currentUserEmail;
+              const startDate = device.usage?.start_date;
 
               return (
                 <TableRow key={device.id}>
@@ -71,8 +72,9 @@ function DesktopView({ devices, currentUserEmail }: BusyDevicesProps) {
                   <TableCell>
                     <EstimatedTimeDisplay
                       deviceId={device.id}
-                      estimatedTime={estimatedUseUntil}
+                      estimatedUseUntil={estimatedUseUntil}
                       isCurrentUser={isCurrentUser}
+                      deviceStartDate={startDate}
                     />
                   </TableCell>
                   <TableCell>
@@ -138,8 +140,9 @@ function MobileView({ devices, currentUserEmail }: BusyDevicesProps) {
                   <span>
                     <EstimatedTimeDisplay
                       deviceId={device.id}
-                      estimatedTime={estimatedUseUntil}
+                      estimatedUseUntil={estimatedUseUntil}
                       isCurrentUser={isCurrentUser}
+                      deviceStartDate={device.usage?.start_date}
                     />
                   </span>
                 </div>
@@ -155,17 +158,20 @@ function MobileView({ devices, currentUserEmail }: BusyDevicesProps) {
 // Component to display estimated time (either editable or read-only)
 function EstimatedTimeDisplay({
   deviceId,
-  estimatedTime,
+  estimatedUseUntil,
   isCurrentUser,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  deviceStartDate,
 }: {
   deviceId: string;
-  estimatedTime: Date | null;
+  estimatedUseUntil: Date | null;
   isCurrentUser: boolean;
+  deviceStartDate: Date;
 }) {
   return isCurrentUser ? (
-    <InlineTimeEdit deviceId={deviceId} estimatedUseUntil={estimatedTime} />
+    <InlineTimeEdit deviceId={deviceId} estimatedUseUntil={estimatedUseUntil} />
   ) : (
-    formatEstimatedTime(estimatedTime)
+    formatEstimatedTime(estimatedUseUntil)
   );
 }
 

--- a/src/components/custom/devices/busy-devices.tsx
+++ b/src/components/custom/devices/busy-devices.tsx
@@ -160,7 +160,6 @@ function EstimatedTimeDisplay({
   deviceId,
   estimatedUseUntil,
   isCurrentUser,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   deviceStartDate,
 }: {
   deviceId: string;
@@ -169,7 +168,11 @@ function EstimatedTimeDisplay({
   deviceStartDate: Date;
 }) {
   return isCurrentUser ? (
-    <InlineTimeEdit deviceId={deviceId} estimatedUseUntil={estimatedUseUntil} />
+    <InlineTimeEdit
+      deviceId={deviceId}
+      estimatedUseUntil={estimatedUseUntil}
+      deviceStartDate={deviceStartDate}
+    />
   ) : (
     formatEstimatedTime(estimatedUseUntil)
   );

--- a/src/components/custom/devices/device-usage-time-picker.tsx
+++ b/src/components/custom/devices/device-usage-time-picker.tsx
@@ -20,6 +20,7 @@ import {
   getDateTimeLocalValue,
   isDateInFuture,
   isWithinEightHours,
+  parseDateTimeLocalInput,
 } from "@/lib/utils";
 
 interface DeviceUsageTimePickerProps {
@@ -32,14 +33,14 @@ export function DeviceUsageTimePicker({
   deviceIp,
 }: DeviceUsageTimePickerProps) {
   const [isLoading, setIsLoading] = useState(false);
-  const [estimatedDateTime, setEstimatedDateTime] = useState<string>("");
+  const [dateTimeInputValue, setDateTimeInputValue] = useState<string>("");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSwitchOn, setIsSwitchOn] = useState(false);
   const [timeError, setTimeError] = useState<string | null>(null);
 
   // Validate the selected date and return an error message if invalid
   const validateDateTime = (dateTimeStr: string): string | null => {
-    const selectedDate = new Date(dateTimeStr);
+    const selectedDate = parseDateTimeLocalInput(dateTimeStr);
 
     // Validate if date is in the future
     if (!isDateInFuture(selectedDate)) {
@@ -61,7 +62,7 @@ export function DeviceUsageTimePicker({
       setIsSwitchOn(true);
       setIsDialogOpen(true);
       // Update the time to current time + 1 minute whenever dialog opens
-      setEstimatedDateTime(getDateTimeLocalValue(getCurrentDatePlusOneMin()));
+      setDateTimeInputValue(getDateTimeLocalValue(getCurrentDatePlusOneMin()));
       setTimeError(null);
     } else {
       //since the user never manually turns off the switch within the active device list this part is never reached
@@ -77,7 +78,7 @@ export function DeviceUsageTimePicker({
   };
 
   const handleTimeChange = (value: string) => {
-    setEstimatedDateTime(value);
+    setDateTimeInputValue(value);
     setTimeError(validateDateTime(value));
   };
 
@@ -86,7 +87,7 @@ export function DeviceUsageTimePicker({
     if (isLoading || timeError) return;
 
     // Validate time again before proceeding
-    const error = validateDateTime(estimatedDateTime);
+    const error = validateDateTime(dateTimeInputValue);
     if (error) {
       setTimeError(error);
       return;
@@ -94,7 +95,7 @@ export function DeviceUsageTimePicker({
 
     try {
       setIsLoading(true);
-      const selectedDate = new Date(estimatedDateTime);
+      const selectedDate = new Date(dateTimeInputValue);
 
       const result = await turnOnDeviceAction(deviceId, deviceIp, selectedDate);
 
@@ -164,7 +165,7 @@ export function DeviceUsageTimePicker({
               <Input
                 id={`est-time-${deviceId}`}
                 type="datetime-local"
-                value={estimatedDateTime}
+                value={dateTimeInputValue}
                 onChange={(e) => handleTimeChange(e.target.value)}
                 min={getDateTimeLocalValue(getCurrentDatePlusOneMin())}
                 max={getDateTimeLocalValue(getCurrentDatePlusEightHours())}

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -123,19 +123,6 @@ export function InlineTimeEdit({
     if (e.key === "Escape") {
       e.preventDefault();
       setIsEditing(false);
-    } else if (e.key === "Enter" && !e.shiftKey) {
-      const target = e.target;
-      // If Enter was pressed on the input, handle validation and submission
-      if (inputRef.current === target) {
-        e.preventDefault(); // Only prevent default for input/submit button
-        //TODO:: see if we can remove these checks
-        const clientError = validateTime();
-        const isUnchanged = isInputUnchanged();
-        if (!clientError && !isUnchanged && !isPending) {
-          formRef.current?.requestSubmit();
-        }
-      }
-      // Let browser handle Enter on other elements (like cancel button)
     }
   };
 

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -139,13 +139,7 @@ export function InlineTimeEdit({
       return "Invalid date format";
     }
 
-    if (
-      !isDateInFuture(selectedDate, (d1, d2) => {
-        if (deviceId !== "d9df82f94a462befde8d8a7d2a64fabf") return;
-        console.log("🚀 ~ !isDateInFuture ~ d2:", d2);
-        console.log("🚀 ~ !isDateInFuture ~ d1:", d1);
-      })
-    ) {
+    if (!isDateInFuture(selectedDate)) {
       return "Time must be in the future";
     }
 

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -10,8 +10,8 @@ import {
   getDateTimeLocalValue,
   isDateInFuture,
   isWithinEightHoursFromDate,
-  parseDateTimeLocal,
-  compareToMinutePrecision,
+  parseDateTimeLocalInput,
+  areDatesEqualToMinute,
 } from "@/lib/utils";
 import { useActionState } from "react";
 import { updateEstimatedTimeAction } from "@/lib/actions/usage-actions";
@@ -133,7 +133,7 @@ export function InlineTimeEdit({
     }
 
     // Parse the input value using our consistent utility
-    const selectedDate = parseDateTimeLocal(inputDateTimeValue);
+    const selectedDate = parseDateTimeLocalInput(inputDateTimeValue);
 
     if (isNaN(selectedDate.getTime())) {
       return "Invalid date format";
@@ -164,10 +164,10 @@ export function InlineTimeEdit({
     if (!displayTime) return false;
 
     // Use parseDateTimeLocal to ensure consistent date handling
-    const selectedDateTime = parseDateTimeLocal(inputDateTimeValue);
+    const selectedDateTime = parseDateTimeLocalInput(inputDateTimeValue);
 
-    // Use compareToMinutePrecision for consistent UTC comparison
-    return compareToMinutePrecision(selectedDateTime, displayTime) === 0;
+    // Use areDatesEqualToMinute for consistent UTC comparison
+    return areDatesEqualToMinute(selectedDateTime, displayTime);
   };
 
   if (!isEditing)

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -19,6 +19,7 @@ import { updateEstimatedTimeAction } from "@/lib/actions/usage-actions";
 interface InlineTimeEditProps {
   deviceId: string;
   estimatedUseUntil: Date | null;
+  deviceStartDate: Date;
 }
 
 export function InlineTimeEdit({

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -25,6 +25,7 @@ interface InlineTimeEditProps {
 export function InlineTimeEdit({
   deviceId,
   estimatedUseUntil,
+  deviceStartDate,
 }: InlineTimeEditProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputDateTimeValue, setInputDateTimeValue] = useState<string>("");
@@ -150,10 +151,8 @@ export function InlineTimeEdit({
     }
 
     // Validate if date is within 8 hours of the original estimated time
-    if (
-      !isWithinEightHoursFromDate(selectedDate, estimatedUseUntil ?? new Date())
-    ) {
-      return "A cannot be blocked for more than 8 hours from the original estimated time";
+    if (!isWithinEightHoursFromDate(selectedDate, deviceStartDate)) {
+      return "Date must be within 8 hours of the start date";
     }
 
     return null; // No error
@@ -215,9 +214,7 @@ export function InlineTimeEdit({
             // min={getDateTimeLocalValue(new Date())}
             min={getDateTimeLocalValue(getCurrentDatePlusOneMin())}
             max={getDateTimeLocalValue(
-              new Date(
-                (displayTime?.getTime() ?? Date.now()) + 8 * 60 * 60 * 1000,
-              ),
+              new Date(deviceStartDate.getTime() + 8 * 60 * 60 * 1000),
             )}
             className={cn(
               "h-8 w-full pr-2",

--- a/src/components/custom/devices/inline-time-edit.tsx
+++ b/src/components/custom/devices/inline-time-edit.tsx
@@ -208,7 +208,7 @@ export function InlineTimeEdit({
           <Input
             ref={inputRef}
             type="datetime-local"
-            name="estimatedTime"
+            name="estimatedDateTimeLocal"
             value={inputDateTimeValue}
             onChange={handleInputChange}
             // min={getDateTimeLocalValue(new Date())}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -66,9 +66,9 @@ function getEnergyValueForDate(date?: string | null): number {
 /**
  * Normalizes a date to minute precision by setting seconds and milliseconds to 0
  */
-export function normalizeToMinute(date: Date): Date {
-  return new Date(new Date(date).setSeconds(0, 0));
-}
+// export function normalizeToMinute(date: Date): Date {
+//   return new Date(new Date(date).setSeconds(0, 0));
+// }
 
 /**
  * Converts a date to UTC timestamp with minute precision
@@ -126,21 +126,20 @@ export const sliceISOStringUptoMinute = (isoString: string): string => {
  * Note: The browser interprets datetime-local values in the local timezone.
  * This function just creates a standard Date object from the input.
  */
-export function parseDateTimeLocal(dateTimeStr: string): Date {
+export function parseDateTimeLocalInput(dateTimeStr: string): Date {
   if (!dateTimeStr) return new Date();
 
   const date = new Date(dateTimeStr);
   return date;
 }
 
-//TODO:: see if we can remove this function
 /**
  * @description Get the local date-time string in YYYY-MM-DDTHH:MM format.
  * Useful for input type="datetime-local"
  * @param date - Date object (default: new Date())
  * @returns Local date-time string in YYYY-MM-DDTHH:MM format
  *
- * @example getDateTimeLocalValue() => "2023-01-01T00:00"
+ * @example getDateTimeLocalValue(new Date("2023-01-01")) => "2023-01-01T00:00"
  * */
 export const getDateTimeLocalValue = (date: Date | null): string => {
   if (date === null) return "";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,9 +84,15 @@ export function areDatesEqualToMinute(date1: Date, date2: Date): boolean {
  * Checks if a date is in the future at minute precision
  * @returns true if the date is in the future
  */
-export function isDateInFuture(date: Date): boolean {
+export function isDateInFuture(
+  date: Date,
+  cb?: (d1: Date, d2: Date) => void,
+): boolean {
   const normalized = normalizeToMinute(date);
   const normalizedNow = normalizeToMinute(new Date());
+  if (cb) {
+    cb(normalized, normalizedNow);
+  }
   return normalized.getTime() > normalizedNow.getTime();
 }
 
@@ -136,6 +142,20 @@ export const isWithinEightHours = (date: Date): boolean => {
     getCurrentDatePlusEightHours(),
   );
   return normalizedDate.getTime() <= normalizedEightHoursLater.getTime();
+};
+
+// Helper function to check if a date is within 8 hours from now
+export const isWithinEightHoursFromDate = (
+  givenDate: Date,
+  fromDate: Date,
+): boolean => {
+  const oneMin = 60 * 1000; // 1 minute in milliseconds
+  const oneHour = 60 * oneMin; // 1 hour in milliseconds
+  const nrmlzdDate = normalizeToMinute(givenDate);
+  const nrmalzdEightHoursLater = normalizeToMinute(
+    new Date(fromDate.getTime() + 8 * oneHour),
+  );
+  return nrmlzdDate.getTime() <= nrmalzdEightHoursLater.getTime();
 };
 
 //using this sytax for making istanbul ignore next work.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -103,14 +103,8 @@ export function areDatesEqualToMinute(date1: Date, date2: Date): boolean {
  * Checks if a date is in the future at minute precision
  * @returns true if the date is in the future
  */
-export function isDateInFuture(
-  date: Date,
-  cb?: (d1: Date, d2: Date) => void,
-): boolean {
+export function isDateInFuture(date: Date): boolean {
   const now = new Date();
-  if (cb) {
-    cb(date, now);
-  }
   return compareToMinutePrecision(date, now) > 0;
 }
 


### PR DESCRIPTION
## Info
1. While applying the validation on the client side, I realised that the deviceStartDate can be used to validate the 8hr time limit and is the better way to do it. Hence I implemented it. 
2. So the component and the formAction both will use the startDate as the basis to check for 8hr validation.