### PR TITLE
Basic Usage Page

### DIFF
--- a/__tests__/lib/data/devices.test.ts
+++ b/__tests__/lib/data/devices.test.ts
@@ -4,6 +4,7 @@ import {
   turnOffDevice,
   getActiveDevice,
   getDevicesWithStatus,
+  getAllDevicesOnlyIdAndAlias,
 } from "@/lib/data/devices";
 import { PrismaClient } from "@prisma/client";
 import { DeepMockProxy } from "jest-mock-extended";
@@ -22,6 +23,22 @@ describe("Device data functions", () => {
     jest.clearAllMocks();
   });
 
+  describe("getAllDevicesOnlyIdAndAlias", () => {
+    it("should return an array of devices with only the id and alias", async () => {
+      mockDB.device.findMany.mockResolvedValueOnce(mockDevices as any);
+
+      const result = await getAllDevicesOnlyIdAndAlias();
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            alias: expect.any(String),
+          }),
+        ]),
+      );
+    });
+  });
   describe("getActiveDevice", () => {
     it("should successfully retrieve an active device", async () => {
       const mockActiveDevice = createMockActiveDeviceRecord();
@@ -587,6 +604,17 @@ const TEST_DATA = {
   specialIp: "192.168.0.190",
   apiEndpoint: "http://api.example.com",
 };
+
+const mockDevices = [
+  {
+    id: "device-1",
+    alias: "Device 1",
+  },
+  {
+    id: "device-2",
+    alias: "Device 2",
+  },
+];
 
 // Helper function to create mock usage record
 const createMockUsageRecord = (

--- a/__tests__/lib/data/devices.test.ts
+++ b/__tests__/lib/data/devices.test.ts
@@ -11,11 +11,15 @@ import { DeepMockProxy } from "jest-mock-extended";
 import * as utils from "@/lib/utils";
 
 // Mock the utils module to mock the simulateApiCall function
-jest.mock("@/lib/utils", () => ({
-  simulateApiCall: jest.fn().mockResolvedValue({
-    usage: { today_energy: 42 },
-  }),
-}));
+jest.mock("@/lib/utils", () => {
+  const original = jest.requireActual("@/lib/utils");
+  return {
+    ...original,
+    simulateApiCall: jest.fn().mockResolvedValue({
+      usage: { today_energy: 42 },
+    }),
+  };
+});
 
 describe("Device data functions", () => {
   // Reset all mocks before each test

--- a/__tests__/lib/data/usage.test.ts
+++ b/__tests__/lib/data/usage.test.ts
@@ -1,9 +1,26 @@
 import { db } from "@/lib/db";
-import { updateEstimatedTime } from "@/lib/data/usage";
-import { PrismaClient } from "@prisma/client";
+import { updateEstimatedTime, getUsageData } from "@/lib/data/usage";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { DeepMockProxy } from "jest-mock-extended";
 
 const mockDB = db as unknown as DeepMockProxy<PrismaClient>;
+
+// Mock Prisma.sql
+jest.mock("@prisma/client", () => {
+  const actual = jest.requireActual("@prisma/client");
+  return {
+    ...actual,
+    Prisma: {
+      ...actual.Prisma,
+      sql: jest.fn((strings: TemplateStringsArray, ...values: any[]) => {
+        return {
+          sql: strings.join(""),
+          values,
+        };
+      }),
+    },
+  };
+});
 
 describe("Usage data functions", () => {
   beforeEach(() => {
@@ -53,6 +70,56 @@ describe("Usage data functions", () => {
       await expect(
         updateEstimatedTime(mockUsageId, mockNewTime),
       ).rejects.toThrow("Some DB error");
+    });
+  });
+
+  describe("getUsageData function", () => {
+    const mockUsageData = [
+      {
+        period: new Date("2024-03-20T00:00:00Z"),
+        consumption: 10,
+        userEmail: "test@example.com",
+      },
+      {
+        period: new Date("2024-03-21T00:00:00Z"),
+        consumption: 20,
+        userEmail: "test@example.com",
+      },
+    ];
+
+    it("should return correct usage data when filtering by device ID", async () => {
+      // Mock the db.$queryRaw method to return a predefined set of usage data
+      mockDB.$queryRaw.mockResolvedValueOnce(mockUsageData);
+
+      // Call the getUsageData function with a specific device ID
+      const deviceId = "device-123";
+      const startDate = new Date("2024-03-19T00:00:00Z");
+      const endDate = new Date("2024-03-22T00:00:00Z");
+
+      const result = await getUsageData({ deviceId, startDate, endDate });
+
+      // Verify the SQL query construction
+      expect(Prisma.sql).toHaveBeenCalledWith(
+        ["AND device_id = ", ""],
+        deviceId,
+      );
+
+      // Verify the result matches the expected mock data
+      expect(result).toEqual(mockUsageData);
+    });
+
+    it("should return correct usage data without device ID filter", async () => {
+      mockDB.$queryRaw.mockResolvedValueOnce(mockUsageData);
+
+      const startDate = new Date("2024-03-19T00:00:00Z");
+      const endDate = new Date("2024-03-22T00:00:00Z");
+
+      const result = await getUsageData({ startDate, endDate });
+
+      // Verify empty SQL was used when no deviceId
+      expect(Prisma.sql).toHaveBeenCalledWith([""]);
+
+      expect(result).toEqual(mockUsageData);
     });
   });
 });

--- a/__tests__/lib/usage-utils.test.ts
+++ b/__tests__/lib/usage-utils.test.ts
@@ -1,0 +1,91 @@
+import {
+  getCurrentWeekRange,
+  getCurrentMonthRange,
+  getCurrentBillingPeriodRange,
+  getDateRangeForTimePeriod,
+  type TimePeriod,
+} from "@/lib/usage-utils";
+import { startOfWeek, endOfWeek, startOfMonth, endOfMonth } from "date-fns";
+
+describe("Usage Utils", () => {
+  const mockToday = new Date("2024-03-15"); // A Friday
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(mockToday);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe("getCurrentWeekRange", () => {
+    it("should return correct week range starting from Sunday", () => {
+      const result = getCurrentWeekRange();
+      const expectedStart = startOfWeek(mockToday, { weekStartsOn: 0 });
+      const expectedEnd = endOfWeek(mockToday, { weekStartsOn: 0 });
+
+      expect(result.start).toEqual(expectedStart);
+      expect(result.end).toEqual(expectedEnd);
+      expect(result.formatted.start).toBe("Mar 10, 2024");
+      // test if the start date is a Sunday
+      expect(result.start.getDay()).toBe(0);
+      expect(result.formatted.end).toBe("Mar 16, 2024");
+      // test if the end date is a Saturday
+      expect(result.end.getDay()).toBe(6);
+    });
+  });
+
+  describe("getCurrentMonthRange", () => {
+    it("should return correct month range", () => {
+      const result = getCurrentMonthRange();
+      const expectedStart = startOfMonth(mockToday);
+      const expectedEnd = endOfMonth(mockToday);
+
+      expect(result.start).toEqual(expectedStart);
+      expect(result.end).toEqual(expectedEnd);
+      expect(result.formatted.start).toBe("Mar 01, 2024");
+      expect(result.formatted.end).toBe("Mar 31, 2024");
+    });
+  });
+
+  describe("getCurrentBillingPeriodRange", () => {
+    it("should return correct billing period range", () => {
+      const billingStartDate = "01-MAR-2024";
+      const result = getCurrentBillingPeriodRange(billingStartDate);
+
+      expect(result.start).toEqual(new Date(billingStartDate));
+      expect(result.end).toEqual(mockToday);
+      expect(result.formatted.start).toBe("Mar 01, 2024");
+      expect(result.formatted.end).toBe("Mar 15, 2024");
+    });
+  });
+
+  describe("getDateRangeForTimePeriod", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = {
+        ...originalEnv,
+        NEXT_PUBLIC_BILLING_START_DATE: "01-MAR-2024",
+      };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it.each<TimePeriod>([
+      "current week",
+      "current month",
+      "current billing period",
+    ])("should return correct date range for %s", (timePeriod) => {
+      const result = getDateRangeForTimePeriod(timePeriod);
+      expect(result).toBeDefined();
+      expect(result.start).toBeInstanceOf(Date);
+      expect(result.end).toBeInstanceOf(Date);
+      expect(result.formatted.start).toMatch(/^[A-Za-z]{3} \d{2}, \d{4}$/);
+      expect(result.formatted.end).toMatch(/^[A-Za-z]{3} \d{2}, \d{4}$/);
+    });
+  });
+});

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -10,6 +10,7 @@ import {
   isWithinEightHours,
   isWithinEightHoursFromDate,
   parseDateTimeLocalInputClient,
+  roundUpTwoDecimals,
   // normalizeToMinute,
   sliceISOStringUptoMinute,
   toUTCMinutePrecision,
@@ -30,6 +31,18 @@ describe("date utils", () => {
   //     expect(normalized.getHours()).toBe(12);
   //   });
   // });
+
+  describe("roundUpTwoDecimals", () => {
+    it("should round up a number to 2 decimal places", () => {
+      const result = roundUpTwoDecimals(10.1234);
+      expect(result).toBe(10.13);
+    });
+
+    it("should round up a number to 2 decimal places", () => {
+      const result = roundUpTwoDecimals(10.0006);
+      expect(result).toBe(10.01);
+    });
+  });
 
   describe("toUTCMinutePrecision", () => {
     it("should correctly convert a local date to UTC timestamp with minute precision", () => {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "urjaamaapakaha",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "pnpm prisma:generate && next build",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.477.0",
     "next": "15.2.0",
     "next-auth": "5.0.0-beta.25",
@@ -43,7 +44,8 @@
     "react-dom": "^19.0.0",
     "sonner": "^2.0.2",
     "tailwind-merge": "^3.0.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-react:
         specifier: ^0.477.0
         version: 0.477.0(react@19.0.0)
@@ -68,6 +71,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.0.14)
+      zod:
+        specifier: ^3.24.4
+        version: 3.24.4
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -1806,6 +1812,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3902,6 +3911,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.2': {}
@@ -5620,6 +5632,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:
@@ -8028,3 +8042,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-select':
+        specifier: ^2.2.4
+        version: 2.2.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.10)(react@19.0.0)
@@ -876,11 +879,30 @@ packages:
   '@prisma/get-platform@6.5.0':
     resolution: {integrity: sha512-xYcvyJwNMg2eDptBYFqFLUCfgi+wZLcj6HDMsj0Qw0irvauG4IKmkbywnqwok0B+k+W+p+jThM2DKTSmoPCkzw==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
+  '@radix-ui/primitive@1.1.2':
+    resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
   '@radix-ui/react-arrow@1.1.2':
     resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.6':
+    resolution: {integrity: sha512-2JMfHJf/eVnwq+2dewT3C0acmCWD3XiVA1Da+jTDqo342UlU13WvXtqHhG+yJw5JeQmu4ue2eMy6gcEArLBlcw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -918,6 +940,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.6':
+    resolution: {integrity: sha512-PbhRFK4lIEw9ADonj48tiYWzkllz81TM7KVYyyMMw2cwHO7D5h4XKEblL8NlaRisTK3QTe6tBEhDccFUryxHBQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -927,8 +962,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.1':
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -958,8 +1011,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.5':
     resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.9':
+    resolution: {integrity: sha512-way197PiTvNp+WBP7svMJasHl+vibhWGQDb6Mgf5mhEWJkgb85z7Lfl9TUdkqpWsf8GRNmoopx9ZxCyDzmgRMQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -993,6 +1068,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.2':
+    resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.2':
     resolution: {integrity: sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==}
     peerDependencies:
@@ -1006,8 +1090,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-scope@1.1.6':
+    resolution: {integrity: sha512-r9zpYNUQY+2jWHWZGyddQLL9YHkM/XvSFHVcWs7bdVuxMAnCwTAuy6Pf47Z4nw7dYcUou1vg/VgjjrrH03VeBw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.0':
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1054,8 +1160,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.6':
+    resolution: {integrity: sha512-7iqXaOWIjDBfIG7aq8CUEeCSsQMLFdn7VEE8TaFz704DtEzpPHR7w/uuzRflvKgltqSAImgcmxQ7fFX3X7wasg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.4':
     resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.8':
+    resolution: {integrity: sha512-hQsTUIn7p7fxCPvao/q6wpbxmCwgLrlz+nOrJgC+RwfZqWY/WN+UMqkXzrtKbPrF82P43eCTl3ekeKuyAQbFeg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1093,6 +1225,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.2':
+    resolution: {integrity: sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.2':
     resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
     peerDependencies:
@@ -1106,8 +1251,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.2.4':
+    resolution: {integrity: sha512-/OOm58Gil4Ev5zT8LyVzqfBcij4dTHYdeyuF5lMHZ2bIp0Lk9oETocYiJ5QC0dHekEQnK6L/FNJCceeb4AkZ6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.1.2':
     resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.2':
+    resolution: {integrity: sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1150,8 +1317,35 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.1.0':
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1168,8 +1362,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1186,6 +1398,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.0':
     resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
     peerDependencies:
@@ -1195,8 +1416,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.0':
     resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1217,8 +1456,24 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.2':
+    resolution: {integrity: sha512-ORCmRUbNiZIv6uV5mhFrhsIKw4UX/N3syZtyqvry61tbGm4JlgQuSn0hk5TwCARsCjkcnuRkSdCE3xfb+ADHew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -4629,11 +4884,24 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.5.0
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.2': {}
 
   '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-arrow@1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4664,13 +4932,37 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-collection@1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-context@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -4704,6 +4996,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-direction@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -4711,6 +5009,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.0.0)
       '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-dismissable-layer@1.1.9(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4738,6 +5049,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-focus-guards@1.1.2(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-focus-scope@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.0.0)
@@ -4749,9 +5066,27 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-focus-scope@1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-id@1.1.0(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
@@ -4809,10 +5144,38 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-popper@1.2.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-arrow': 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-portal@1.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-portal@1.1.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4838,6 +5201,15 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-primitive@2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -4855,9 +5227,45 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-select@2.2.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.9(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-popper': 1.2.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-visually-hidden': 1.2.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      aria-hidden: 1.2.4
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.6.3(@types/react@19.0.10)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-slot@1.1.2(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-slot@1.2.2(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
@@ -4903,9 +5311,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
@@ -4917,13 +5346,32 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-use-previous@1.1.0(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -4936,9 +5384,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
   '@radix-ui/react-use-size@1.1.0(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.10
@@ -4952,7 +5414,18 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-visually-hidden@1.2.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/rect@1.1.0': {}
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rtsao/scc@1.1.0': {}
 

--- a/scripts/database/refresh-usage.js
+++ b/scripts/database/refresh-usage.js
@@ -1,0 +1,78 @@
+import { neon } from "@neondatabase/serverless";
+import { generateUsage } from "./populate-db.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const BILLING_START_DATE =
+  process.env.NEXT_PUBLIC_BILLING_START_DATE ||
+  new Date().toISOString().split("T")[0];
+
+async function clearActiveUsages() {
+  const sql = neon(DATABASE_URL);
+  try {
+    console.log("Clearing active usages...");
+    await sql`DELETE FROM active_usage`;
+  } catch (error) {
+    console.error("Error clearing active usages:", error);
+    throw error;
+  }
+}
+
+async function clearUsageTable() {
+  const sql = neon(DATABASE_URL);
+  try {
+    console.log("Clearing usage table...");
+    await sql`DELETE FROM usage`;
+    console.log("Usage table cleared successfully");
+  } catch (error) {
+    console.error("Error clearing usage table:", error);
+    throw error;
+  }
+}
+
+export async function refreshUsageData(startDateStr = BILLING_START_DATE) {
+  const sql = neon(DATABASE_URL);
+  try {
+    // Clear active usages first
+    await clearActiveUsages();
+    // Clear existing usage data
+    await clearUsageTable();
+
+    // Get all active devices
+    const devices = await sql`SELECT * FROM device WHERE is_archived = false`;
+    console.log(`Found ${devices.length} active devices`);
+
+    // Calculate date range
+    const startDate = new Date(startDateStr);
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 100);
+
+    // Generate usage records
+    const usageLogs = generateUsage(devices, 100, startDate, endDate);
+
+    // Insert usage records
+    console.log("Inserting new usage records...");
+    const usageQueries = usageLogs.map(
+      (log) =>
+        sql`
+        INSERT INTO usage (user_email, start_date, end_date, estimated_use_time, consumption, charge, device_id)
+        VALUES (${log.user_email}, ${log.start_date}, ${log.end_date}, ${log.estimated_use_time}, ${log.consumption}, ${log.charge}, ${log.device_id})
+      `,
+    );
+
+    await sql.transaction(usageQueries);
+    console.log(`Successfully inserted ${usageLogs.length} usage records`);
+  } catch (error) {
+    console.error("Error refreshing usage data:", error);
+    throw error;
+  }
+}
+
+console.log("process.argv[1]:: ", process.argv[1]);
+console.log("import.meta.url:: ", import.meta.url);
+// Run the script if called directly
+if (import.meta.url.includes("refresh-usage.js")) {
+  const startDate = process.argv[2] || BILLING_START_DATE;
+  refreshUsageData(startDate)
+    .then(() => console.log("Usage data refresh completed!"))
+    .catch((err) => console.error("Script failed:", err));
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,24 @@
 @theme {
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --animate-fade-in: fade-in 1s ease-in;
+  @keyframes fade-in {
+    0% {
+      opacity: 0;
+      background-color: var(--color-blue-300);
+    }
+    50% {
+      opacity: 0.25;
+      background-color: var(--color-blue-200);
+    }
+    75% {
+      opacity: 0.5;
+      background-color: var(--color-blue-100);
+    }
+    100% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,14 +28,9 @@ export default async function RootLayout({
   const session = await auth();
 
   return (
-    <html
-      lang="en"
-      style={{ scrollbarGutter: "stable both-edges" }}
-      suppressHydrationWarning
-    >
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} grid min-h-[100svh] grid-cols-1 grid-rows-[auto_1fr] antialiased`}
-        style={{ scrollbarGutter: "stable both-edges" }}
+        className={`${geistSans.variable} ${geistMono.variable} mr-3.5 ml-3.5 grid min-h-[100svh] grid-cols-1 grid-rows-[auto_1fr] antialiased`}
       >
         <ThemeProvider
           attribute="class"

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -1,3 +1,7 @@
 export default function Usage() {
-  return <div>Usage</div>;
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="mb-8 text-3xl font-bold">Usage Dashboard</h1>
+    </div>
+  );
 }

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -1,12 +1,9 @@
 import ChartWithFilters from "@/components/custom/usage/chart-with-filters";
 import { getAllDevicesOnlyIdAndAlias } from "@/lib/data/devices";
-import { deviceSelectListResponseSchema } from "@/lib/zod/usage";
 
 export default async function Usage() {
-  // get all devices
-  const devices = await getAllDevicesOnlyIdAndAlias();
-  // we only need the device id and name
-  const devicesWithIdAndName = deviceSelectListResponseSchema.parse(devices);
+  const devicesWithIdAndName = await getAllDevicesOnlyIdAndAlias();
+
   return (
     <div className="container mx-auto py-6">
       <h1 className="mb-8 text-3xl font-bold">Usage Dashboard</h1>

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -1,7 +1,18 @@
-export default function Usage() {
+import ChartWithFilters from "@/components/custom/usage/chart-with-filters";
+import { getAllDevicesOnlyIdAndAlias } from "@/lib/data/devices";
+import { deviceSelectListResponseSchema } from "@/lib/zod/usage";
+
+export default async function Usage() {
+  // get all devices
+  const devices = await getAllDevicesOnlyIdAndAlias();
+  // we only need the device id and name
+  const devicesWithIdAndName = deviceSelectListResponseSchema.parse(devices);
   return (
     <div className="container mx-auto py-6">
       <h1 className="mb-8 text-3xl font-bold">Usage Dashboard</h1>
+      <div className="flex">
+        <ChartWithFilters devices={devicesWithIdAndName} />
+      </div>
     </div>
   );
 }

--- a/src/components/custom/usage/chart-with-filters.tsx
+++ b/src/components/custom/usage/chart-with-filters.tsx
@@ -1,15 +1,117 @@
+"use client";
 import { type DeviceSelectionList } from "@/lib/zod/usage";
 import FiltersForm from "./filters-form";
+import { useEffect, useState, useTransition } from "react";
+import { getUsageDataAction } from "@/lib/actions/usage-actions";
+import { getDateRangeForTimePeriod, type TimePeriod } from "@/lib/usage-utils";
+import { roundUpTwoDecimals } from "@/lib/utils";
+
 export default function ChartWithFilters({
   devices,
 }: {
   devices: DeviceSelectionList;
 }) {
+  const [usageData, setUsageData] =
+    useState<Awaited<ReturnType<typeof getUsageDataAction>>>();
+  console.log("📜usageData:: ", usageData);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [selectedTimePeriod, setSelectedTimePeriod] =
+    useState<TimePeriod>("current week");
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [isPending, startTransition] = useTransition();
+
+  const handleDeviceSelect = (deviceId: string) => {
+    if (deviceId === "All") {
+      setSelectedDeviceId(null);
+    } else {
+      setSelectedDeviceId(deviceId);
+    }
+  };
+
+  const handleTimePeriodSelect = (period: TimePeriod) => {
+    setSelectedTimePeriod(period);
+  };
+
+  const dateRange = getDateRangeForTimePeriod(selectedTimePeriod);
+
+  const selectedDeviceValue = selectedDeviceId ?? "All";
+  const selectedDeviceAlias =
+    devices.find((device) => device.id === selectedDeviceId)?.alias || "All";
+
+  useEffect(() => {
+    const fetchUsageData = (
+      deviceId: string | null,
+      timePeriod: TimePeriod,
+    ) => {
+      startTransition(async () => {
+        const result = await getUsageDataAction(
+          timePeriod,
+          dateRange,
+          deviceId || undefined,
+        );
+        setUsageData(result);
+      });
+    };
+    fetchUsageData(selectedDeviceId, selectedTimePeriod);
+  }, [selectedDeviceId, selectedTimePeriod]);
+
   return (
     <div className="flex w-full flex-col">
-      <FiltersForm devices={devices} />
-      <div data-testid="chart" className="flex w-full">
+      <FiltersForm
+        devices={devices}
+        selectedDeviceValue={selectedDeviceValue}
+        selectedDeviceAlias={selectedDeviceAlias}
+        selectedTimePeriod={selectedTimePeriod}
+        handleDeviceSelect={handleDeviceSelect}
+        handleTimePeriodSelect={handleTimePeriodSelect}
+      />
+      <div data-testid="chart" className="flex w-full flex-col gap-2">
+        <p className="text-center text-lg">
+          Showing usage for&nbsp;
+          <em>
+            {selectedDeviceAlias === "All"
+              ? "All Devices"
+              : selectedDeviceAlias}
+          </em>
+          &nbsp;from&nbsp;
+          <em>{dateRange.formatted.start}</em>
+          &nbsp;to&nbsp;
+          <em>{dateRange.formatted.end}</em>
+        </p>
         {/* for now, we will display textual data as per the details in usage-screen-implemenation notepad */}
+        {usageData && (
+          <div className="flex flex-col gap-2">
+            <h3>User vs Total Usage</h3>
+            <p>
+              {usageData.data?.userConsumption.reduce((acc, curr) => {
+                return roundUpTwoDecimals(acc + curr.consumption);
+              }, 0)}
+              &nbsp;vs&nbsp;
+              {usageData.data?.totalConsumption.reduce(
+                (acc, curr) => roundUpTwoDecimals(acc + curr.consumption),
+                0,
+              )}
+            </p>
+            <div className="flex flex-col gap-2">
+              <h4>User Consumption</h4>
+              {usageData.data?.userConsumption.map((item) => (
+                <div key={item.date.toISOString()} className="animate-fade-in">
+                  <p>
+                    {item.date.toLocaleDateString()} - {item.consumption}
+                  </p>
+                </div>
+              ))}
+              <h4>Total Consumption</h4>
+              {usageData.data?.totalConsumption.map((item) => (
+                <div key={item.date.toISOString()} className="animate-fade-in">
+                  <p>
+                    {item.date.toLocaleDateString()} - {item.consumption}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/custom/usage/chart-with-filters.tsx
+++ b/src/components/custom/usage/chart-with-filters.tsx
@@ -1,0 +1,16 @@
+import { type DeviceSelectionList } from "@/lib/zod/usage";
+import FiltersForm from "./filters-form";
+export default function ChartWithFilters({
+  devices,
+}: {
+  devices: DeviceSelectionList;
+}) {
+  return (
+    <div className="flex w-full flex-col">
+      <FiltersForm devices={devices} />
+      <div data-testid="chart" className="flex w-full">
+        {/* for now, we will display textual data as per the details in usage-screen-implemenation notepad */}
+      </div>
+    </div>
+  );
+}

--- a/src/components/custom/usage/device-selector.tsx
+++ b/src/components/custom/usage/device-selector.tsx
@@ -1,0 +1,41 @@
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { type DeviceSelectionList } from "@/lib/zod/usage";
+
+export default function DeviceSelector({
+  devices,
+  onSelect,
+  selectedDeviceValue,
+}: {
+  devices: DeviceSelectionList;
+  onSelect: (deviceId: string) => void;
+  selectedDeviceValue: string;
+}) {
+  return (
+    <Select
+      onValueChange={onSelect}
+      value={selectedDeviceValue}
+      name="deviceId"
+    >
+      <SelectTrigger className="w-[150px] md:w-[200px]">
+        <SelectValue placeholder="Select a device" />
+      </SelectTrigger>
+      <SelectContent position="popper">
+        <SelectGroup>
+          <SelectItem value={"All"}>All</SelectItem>
+          {devices.map((device) => (
+            <SelectItem key={device.id} value={device.id}>
+              {device.alias}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/custom/usage/device-selector.tsx
+++ b/src/components/custom/usage/device-selector.tsx
@@ -12,10 +12,12 @@ export default function DeviceSelector({
   devices,
   onSelect,
   selectedDeviceValue,
+  selectedDeviceAlias,
 }: {
   devices: DeviceSelectionList;
   onSelect: (deviceId: string) => void;
   selectedDeviceValue: string;
+  selectedDeviceAlias: string;
 }) {
   return (
     <Select
@@ -24,11 +26,13 @@ export default function DeviceSelector({
       name="deviceId"
     >
       <SelectTrigger className="w-[150px] md:w-[200px]">
-        <SelectValue placeholder="Select a device" />
+        <SelectValue placeholder="Select a device">
+          {selectedDeviceAlias}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent position="popper">
         <SelectGroup>
-          <SelectItem value={"All"}>All</SelectItem>
+          <SelectItem value="All">All</SelectItem>
           {devices.map((device) => (
             <SelectItem key={device.id} value={device.id}>
               {device.alias}

--- a/src/components/custom/usage/filters-form.tsx
+++ b/src/components/custom/usage/filters-form.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { DeviceSelectionList } from "@/lib/zod/usage";
+import { type DeviceSelectionList } from "@/lib/zod/usage";
 import TimePeriodSelector from "./time-period-selector";
 import DeviceSelector from "./device-selector";
 import { Label } from "@/components/ui/label";
 import { useState } from "react";
+import { getDateRangeForTimePeriod, type TimePeriod } from "@/lib/usage-utils";
 
 export default function FiltersForm({
   devices,
@@ -12,6 +13,8 @@ export default function FiltersForm({
   devices: DeviceSelectionList;
 }) {
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [selectedTimePeriod, setSelectedTimePeriod] =
+    useState<TimePeriod>("current week");
 
   const handleDeviceSelect = (deviceId: string) => {
     console.log("deviceId:: ", deviceId);
@@ -22,11 +25,20 @@ export default function FiltersForm({
     }
   };
 
+  const handleTimePeriodSelect = (period: TimePeriod) => {
+    setSelectedTimePeriod(period);
+  };
+
   const selectedDeviceValue = selectedDeviceId || "All";
   console.log("selectedDeviceValue:: ", selectedDeviceValue);
 
   const selectedDeviceAlias =
     devices.find((device) => device.id === selectedDeviceId)?.alias || "All";
+
+  const dateRange = getDateRangeForTimePeriod(selectedTimePeriod);
+  console.log("Selected time period:", selectedTimePeriod);
+  console.log("Date range:", dateRange);
+
   return (
     <div data-testid="filters-form" className="flex w-full flex-col gap-2">
       <form className="flex w-full justify-between">
@@ -44,14 +56,21 @@ export default function FiltersForm({
           <Label htmlFor="time-period-selector" className="text-lg">
             Time Period
           </Label>
-          <TimePeriodSelector />
+          <TimePeriodSelector
+            onSelect={handleTimePeriodSelect}
+            selectedValue={selectedTimePeriod}
+          />
         </div>
       </form>
       <p className="text-center text-lg">
-        Showing usage for{" "}
+        Showing usage for&nbsp;
         <em>
           {selectedDeviceAlias === "All" ? "All Devices" : selectedDeviceAlias}
         </em>
+        &nbsp;from&nbsp;
+        <em>{dateRange.formatted.start}</em>
+        &nbsp;to&nbsp;
+        <em>{dateRange.formatted.end}</em>
       </p>
     </div>
   );

--- a/src/components/custom/usage/filters-form.tsx
+++ b/src/components/custom/usage/filters-form.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { DeviceSelectionList } from "@/lib/zod/usage";
+import TimePeriodSelector from "./time-period-selector";
+import DeviceSelector from "./device-selector";
+import { Label } from "@/components/ui/label";
+import { useState } from "react";
+
+export default function FiltersForm({
+  devices,
+}: {
+  devices: DeviceSelectionList;
+}) {
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+
+  const handleDeviceSelect = (deviceId: string) => {
+    console.log("deviceId:: ", deviceId);
+    if (deviceId === "All") {
+      setSelectedDeviceId(null);
+    } else {
+      setSelectedDeviceId(deviceId);
+    }
+  };
+
+  const selectedDeviceValue = selectedDeviceId || "All";
+  console.log("selectedDeviceValue:: ", selectedDeviceValue);
+
+  const selectedDeviceAlias =
+    devices.find((device) => device.id === selectedDeviceId)?.alias || "All";
+  return (
+    <div data-testid="filters-form" className="flex w-full flex-col gap-2">
+      <form className="flex w-full justify-between">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="device-selector" className="text-lg">
+            Device
+          </Label>
+          <DeviceSelector
+            devices={devices}
+            onSelect={handleDeviceSelect}
+            selectedDeviceValue={selectedDeviceValue}
+          />
+        </div>
+        <div className="flex flex-col justify-around gap-2">
+          <Label htmlFor="time-period-selector" className="text-lg">
+            Time Period
+          </Label>
+          <TimePeriodSelector />
+        </div>
+      </form>
+      <p className="text-center text-lg">
+        Showing usage for{" "}
+        <em>
+          {selectedDeviceAlias === "All" ? "All Devices" : selectedDeviceAlias}
+        </em>
+      </p>
+    </div>
+  );
+}

--- a/src/components/custom/usage/filters-form.tsx
+++ b/src/components/custom/usage/filters-form.tsx
@@ -4,41 +4,25 @@ import { type DeviceSelectionList } from "@/lib/zod/usage";
 import TimePeriodSelector from "./time-period-selector";
 import DeviceSelector from "./device-selector";
 import { Label } from "@/components/ui/label";
-import { useState } from "react";
-import { getDateRangeForTimePeriod, type TimePeriod } from "@/lib/usage-utils";
+import { type TimePeriod } from "@/lib/usage-utils";
+
+interface FiltersFormProps {
+  devices: DeviceSelectionList;
+  selectedDeviceValue: string;
+  selectedDeviceAlias: string;
+  selectedTimePeriod: TimePeriod;
+  handleDeviceSelect: (deviceId: string) => void;
+  handleTimePeriodSelect: (timePeriod: TimePeriod) => void;
+}
 
 export default function FiltersForm({
   devices,
-}: {
-  devices: DeviceSelectionList;
-}) {
-  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
-  const [selectedTimePeriod, setSelectedTimePeriod] =
-    useState<TimePeriod>("current week");
-
-  const handleDeviceSelect = (deviceId: string) => {
-    console.log("deviceId:: ", deviceId);
-    if (deviceId === "All") {
-      setSelectedDeviceId(null);
-    } else {
-      setSelectedDeviceId(deviceId);
-    }
-  };
-
-  const handleTimePeriodSelect = (period: TimePeriod) => {
-    setSelectedTimePeriod(period);
-  };
-
-  const selectedDeviceValue = selectedDeviceId || "All";
-  console.log("selectedDeviceValue:: ", selectedDeviceValue);
-
-  const selectedDeviceAlias =
-    devices.find((device) => device.id === selectedDeviceId)?.alias || "All";
-
-  const dateRange = getDateRangeForTimePeriod(selectedTimePeriod);
-  console.log("Selected time period:", selectedTimePeriod);
-  console.log("Date range:", dateRange);
-
+  selectedDeviceValue,
+  selectedDeviceAlias,
+  selectedTimePeriod,
+  handleDeviceSelect,
+  handleTimePeriodSelect,
+}: FiltersFormProps) {
   return (
     <div data-testid="filters-form" className="flex w-full flex-col gap-2">
       <form className="flex w-full justify-between">
@@ -50,6 +34,7 @@ export default function FiltersForm({
             devices={devices}
             onSelect={handleDeviceSelect}
             selectedDeviceValue={selectedDeviceValue}
+            selectedDeviceAlias={selectedDeviceAlias}
           />
         </div>
         <div className="flex flex-col justify-around gap-2">
@@ -62,16 +47,6 @@ export default function FiltersForm({
           />
         </div>
       </form>
-      <p className="text-center text-lg">
-        Showing usage for&nbsp;
-        <em>
-          {selectedDeviceAlias === "All" ? "All Devices" : selectedDeviceAlias}
-        </em>
-        &nbsp;from&nbsp;
-        <em>{dateRange.formatted.start}</em>
-        &nbsp;to&nbsp;
-        <em>{dateRange.formatted.end}</em>
-      </p>
     </div>
   );
 }

--- a/src/components/custom/usage/time-period-selector.tsx
+++ b/src/components/custom/usage/time-period-selector.tsx
@@ -22,7 +22,9 @@ export default function TimePeriodSelector({
       name="timePeriod"
     >
       <SelectTrigger className="w-[150px] md:w-[200px]">
-        <SelectValue placeholder="Select time period" />
+        <SelectValue placeholder="Select time period">
+          {selectedValue}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent position="popper">
         <SelectGroup>

--- a/src/components/custom/usage/time-period-selector.tsx
+++ b/src/components/custom/usage/time-period-selector.tsx
@@ -1,0 +1,3 @@
+export default function TimePeriodSelector() {
+  return <div>TimePeriodSelector</div>;
+}

--- a/src/components/custom/usage/time-period-selector.tsx
+++ b/src/components/custom/usage/time-period-selector.tsx
@@ -1,3 +1,38 @@
-export default function TimePeriodSelector() {
-  return <div>TimePeriodSelector</div>;
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { type TimePeriod } from "@/lib/usage-utils";
+
+export default function TimePeriodSelector({
+  onSelect,
+  selectedValue = "current week",
+}: {
+  onSelect: (period: TimePeriod) => void;
+  selectedValue: TimePeriod;
+}) {
+  return (
+    <Select
+      onValueChange={(value) => onSelect?.(value as TimePeriod)}
+      value={selectedValue}
+      name="timePeriod"
+    >
+      <SelectTrigger className="w-[150px] md:w-[200px]">
+        <SelectValue placeholder="Select time period" />
+      </SelectTrigger>
+      <SelectContent position="popper">
+        <SelectGroup>
+          <SelectItem value="current week">Current Week</SelectItem>
+          <SelectItem value="current month">Current Month</SelectItem>
+          <SelectItem value="current billing period">
+            Current Billing Period
+          </SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/lib/actions/usage-actions.ts
+++ b/src/lib/actions/usage-actions.ts
@@ -2,19 +2,39 @@
 
 import { auth } from "@/auth";
 import { getActiveDevice } from "../data/devices";
-import { updateEstimatedTime } from "../data/usage";
+import { updateEstimatedTime, getUsageData } from "../data/usage";
 import {
   areDatesEqualToMinute,
   convertDateTimeLocalToUTC,
   isDateInFuture,
   isWithinEightHoursFromDate,
 } from "../utils";
+import {
+  getDateRangeForTimePeriod,
+  TimePeriod,
+  processUsageData,
+} from "../usage-utils";
 
 // Define the state type
 interface EstimatedTimeState {
   message: string;
   error?: string;
   updatedTime?: Date | null;
+}
+
+interface UsageDataResponse {
+  message: string;
+  error?: string;
+  data?: {
+    userConsumption: {
+      date: Date;
+      consumption: number;
+    }[];
+    totalConsumption: {
+      date: Date;
+      consumption: number;
+    }[];
+  };
 }
 
 /**
@@ -139,6 +159,58 @@ export async function updateEstimatedTimeAction(
     return {
       message: "Error updating date",
       error: "Server Error",
+    };
+  }
+}
+
+/**
+ * Get the usage data for a given time period and deviceId
+ * @param timePeriod - The time period to get the usage data for (e.g. "current week", "current month", "current year")
+ * @param dateRange - The date range to get the usage data for. It must come from the client to account for timezone differences
+ * @param deviceId - The deviceId to get the usage data for
+ * @returns The usage data for the given time period and deviceId
+ */
+export async function getUsageDataAction(
+  timePeriod: TimePeriod,
+  dateRange: Omit<ReturnType<typeof getDateRangeForTimePeriod>, "formatted">,
+  deviceId?: string,
+): Promise<UsageDataResponse> {
+  try {
+    const session = await auth();
+    const userEmail = session?.user?.email;
+
+    if (!userEmail) {
+      return {
+        message: "Unauthorized",
+        error: "Unauthorized",
+      };
+    }
+
+    const usageData = await getUsageData({
+      deviceId,
+      startDate: dateRange.start,
+      endDate: dateRange.end,
+    });
+
+    const { userConsumption, totalConsumption } = processUsageData(
+      usageData,
+      timePeriod,
+      dateRange.start,
+      userEmail,
+    );
+
+    return {
+      message: "Usage data fetched successfully",
+      data: {
+        userConsumption,
+        totalConsumption,
+      },
+    };
+  } catch (error) {
+    console.error("Failed to fetch usage data:", error);
+    return {
+      message: "Failed to fetch usage data",
+      error: error instanceof Error ? error.message : "Unknown error occurred",
     };
   }
 }

--- a/src/lib/data/devices.ts
+++ b/src/lib/data/devices.ts
@@ -2,14 +2,17 @@ import { db } from "@/lib/db";
 import { UsageResponse } from "@/lib/utils";
 import type { device, usage } from "@prisma/client";
 
-/* istanbul ignore next */
-async function getAllDevices() {
+export async function getAllDevicesOnlyIdAndAlias() {
   return db.device.findMany({
     where: {
       is_archived: false,
     },
     orderBy: {
       alias: "asc",
+    },
+    select: {
+      id: true,
+      alias: true,
     },
   });
 }
@@ -286,9 +289,4 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
 }
 
 //using this sytax for making istanbul ignore next work.
-export {
-  getAllDevices,
-  getDeviceById,
-  getDeviceUsage,
-  getDevicesWithActiveStatus,
-};
+export { getDeviceById, getDeviceUsage, getDevicesWithActiveStatus };

--- a/src/lib/usage-utils.ts
+++ b/src/lib/usage-utils.ts
@@ -1,0 +1,80 @@
+import {
+  startOfWeek,
+  endOfWeek,
+  startOfMonth,
+  endOfMonth,
+  format,
+} from "date-fns";
+
+export type TimePeriod =
+  // | "previous week"
+  // | "previous month"
+  // | "previous billing period" // TODO:: this could be a stretch goal
+  "current week" | "current month" | "current billing period";
+
+export const getCurrentWeekRange = () => {
+  const today = new Date();
+  const start = startOfWeek(today, { weekStartsOn: 0 }); // Sunday
+  const end = endOfWeek(today, { weekStartsOn: 0 }); // Saturday
+
+  return {
+    start,
+    end,
+    formatted: {
+      start: format(start, "MMM dd, yyyy"),
+      end: format(end, "MMM dd, yyyy"),
+    },
+  };
+};
+
+export const getCurrentMonthRange = () => {
+  const today = new Date();
+  const start = startOfMonth(today);
+  const end = endOfMonth(today);
+
+  return {
+    start,
+    end,
+    formatted: {
+      start: format(start, "MMM dd, yyyy"),
+      end: format(end, "MMM dd, yyyy"),
+    },
+  };
+};
+
+export const getCurrentBillingPeriodRange = (billingStartDate: string) => {
+  const today = new Date();
+  const start = new Date(billingStartDate);
+  const end = today;
+
+  return {
+    start,
+    end,
+    formatted: {
+      start: format(start, "MMM dd, yyyy"),
+      end: format(end, "MMM dd, yyyy"),
+    },
+  };
+};
+
+export const getDateRangeForTimePeriod = (timePeriod: TimePeriod) => {
+  let dateRange;
+  switch (timePeriod) {
+    case "current week":
+      dateRange = getCurrentWeekRange();
+      break;
+    case "current month":
+      dateRange = getCurrentMonthRange();
+      break;
+    case "current billing period":
+      /* istanbul ignore next */
+      if (!process.env.NEXT_PUBLIC_BILLING_START_DATE) {
+        throw new Error("NEXT_PUBLIC_BILLING_START_DATE is not set");
+      }
+      dateRange = getCurrentBillingPeriodRange(
+        process.env.NEXT_PUBLIC_BILLING_START_DATE,
+      );
+      break;
+  }
+  return dateRange;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,18 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+/**
+ * Rounds up a number to 2 decimal places and returns it as a number
+ * @param value - The number to round up
+ * @returns The rounded up number with 2 decimal places
+ * @example roundUpTwoDecimals(10.1234) => 10.13
+ * @example roundUpTwoDecimals(10.126) => 10.13
+ * @example roundUpTwoDecimals(10.121) => 10.13
+ */
+export function roundUpTwoDecimals(value: number): number {
+  return Number((Math.ceil(value * 100) / 100).toFixed(2));
+}
+
 /* istanbul ignore next */
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/src/lib/zod/usage.ts
+++ b/src/lib/zod/usage.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+// zod schema for device list response
+export const deviceSelectListResponseSchema = z.array(
+  z.object({
+    id: z.string(),
+    alias: z.string().min(1),
+  }),
+);
+
+export type DeviceSelectionList = z.infer<
+  typeof deviceSelectListResponseSchema
+>;


### PR DESCRIPTION
# Changes
1. The usage page will allow users to choose a device and a time period to filter the usage stats.
2. The Page will query the usage of all devices for the current calender week for the currently logged in user and the total usage by default.
3. It simply displays the data in a textual format in `Wh`
4. It aggregates the consumption value based on the `time period` value and group it accordingly.
    a. When time period is `current week`, it aggregates the consumption per day in the week and displays the total value for that day by the user vs the total usage. 
    b. Similarly, for `current month` the values are aggregated and grouped `weekly` and 
    c. for `current billing period` the values are aggregated and grouped `monthly`