### PR TITLE
Bug/mitigate the chance for producing incorrect consumption values

### DIFF
--- a/__tests__/lib/data/devices.test.ts
+++ b/__tests__/lib/data/devices.test.ts
@@ -16,7 +16,7 @@ jest.mock("@/lib/utils", () => {
   return {
     ...original,
     simulateApiCall: jest.fn().mockResolvedValue({
-      usage: { today_energy: 42 },
+      usage: { month_energy: 42 },
     }),
   };
 });
@@ -197,7 +197,7 @@ describe("Device data functions", () => {
 
       // Setup API environment and mock fetch
       setupApiEnvironment();
-      mockFetchApi();
+      mockFetchApi(TEST_DATA.mockFinalConsumption, true);
 
       // Call the function
       await turnOnDevice(
@@ -289,7 +289,7 @@ describe("Device data functions", () => {
       mockDB.active_device.delete.mockResolvedValueOnce({} as any);
 
       jest.spyOn(utils, "simulateApiCall").mockResolvedValueOnce({
-        usage: { today_energy: TEST_DATA.mockFinalConsumption },
+        usage: { month_energy: TEST_DATA.mockFinalConsumption },
       } as any);
 
       // Call the function under test
@@ -383,7 +383,7 @@ describe("Device data functions", () => {
 
       // Setup API environment and mock fetch
       setupApiEnvironment();
-      mockFetchApi();
+      mockFetchApi(TEST_DATA.mockFinalConsumption, false);
 
       // Call the function
       await turnOffDevice(TEST_DATA.deviceId, TEST_DATA.specialIp);
@@ -416,7 +416,7 @@ describe("Device data functions", () => {
 
       // Mock the API call to ensure it's not the source of error
       jest.spyOn(utils, "simulateApiCall").mockResolvedValueOnce({
-        usage: { today_energy: TEST_DATA.mockFinalConsumption },
+        usage: { month_energy: TEST_DATA.mockFinalConsumption },
       } as any);
 
       // Spy on console.error to keep the jest output clean
@@ -449,7 +449,7 @@ describe("Device data functions", () => {
 
       // Mock the API call to ensure it's not the source of error
       jest.spyOn(utils, "simulateApiCall").mockResolvedValueOnce({
-        usage: { today_energy: TEST_DATA.mockFinalConsumption },
+        usage: { month_energy: TEST_DATA.mockFinalConsumption },
       } as any);
 
       // Spy on console.error to keep the jest output clean
@@ -671,10 +671,14 @@ const setupApiEnvironment = () => {
 };
 
 // Helper to mock fetch API
-const mockFetchApi = (energyValue: number = TEST_DATA.mockFinalConsumption) => {
+const mockFetchApi = (
+  energyValue: number = TEST_DATA.mockFinalConsumption,
+  isTurnOn: boolean,
+) => {
   return (global.fetch = jest.fn().mockResolvedValue({
     json: jest.fn().mockResolvedValue({
-      usage: { today_energy: energyValue },
+      usage: { month_energy: energyValue },
+      status: isTurnOn ? 1 : 0,
     }),
   } as any));
 };

--- a/src/lib/data/devices.ts
+++ b/src/lib/data/devices.ts
@@ -191,7 +191,6 @@ export async function turnOnDevice(
           start_date: new Date(),
           end_date: new Date(), // Same as start_date when device is turned on
           estimated_use_time: estimatedUseTime,
-          // consumption: apiResponse.usage.today_energy, // Initial consumption is 0
           consumption: apiResponse.usage.month_energy, // Initial consumption is 0
           charge: 0, // Initial charge is 0
         },
@@ -277,7 +276,6 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
       // Calculate final consumption (current - initial)
       const finalConsumption = shouldCallRealApi
         ? roundUpTwoDecimals(
-            // Number(apiResponse.usage.today_energy) -
             Number(apiResponse.usage.month_energy) -
               Number(activeDevice.usage.consumption),
           )
@@ -286,7 +284,6 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
               Math.ceil(
                 Math.abs(
                   // Math.abs is used to ensure the result is positive
-                  // Number(apiResponse.usage.today_energy) -
                   Number(apiResponse.usage.month_energy) -
                     Number(activeDevice.usage.consumption),
                 ) * 100,

--- a/src/lib/data/devices.ts
+++ b/src/lib/data/devices.ts
@@ -225,12 +225,14 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
       throw new Error("Device is not currently active or missing usage record");
     }
 
-    // Call API/simulate API to get current energy reading
     let apiResponse: UsageResponse;
+
     const shouldCallRealApi =
       process.env.SHOULD_CALL_REAL_API === "1" ||
       process.env.SPECIAL_DEVICE_IPS?.split(",").includes(deviceIp);
+
     if (shouldCallRealApi) {
+      // call real api
       const credentials = Buffer.from(
         `${process.env.URJ_FSFY_API_USER}:${process.env.URJ_FSFY_API_PWD}`,
       ).toString("base64");

--- a/src/lib/data/devices.ts
+++ b/src/lib/data/devices.ts
@@ -1,6 +1,12 @@
 import { db } from "@/lib/db";
-import { roundUpTwoDecimals, UsageResponse } from "@/lib/utils";
+import { roundUpTwoDecimals } from "@/lib/utils";
 import type { device, usage } from "@prisma/client";
+import {
+  deviceOffResponseSchema,
+  type DeviceOffResponse,
+  type DeviceOnResponse,
+  deviceOnResponseSchema,
+} from "../zod/device";
 import { deviceSelectListResponseSchema } from "../zod/usage";
 
 export async function getAllDevicesOnlyIdAndAlias() {
@@ -144,7 +150,7 @@ export async function turnOnDevice(
   estimatedUseTime?: Date,
 ) {
   try {
-    let apiResponse: UsageResponse;
+    let apiResponse: DeviceOnResponse;
     const shouldCallRealApi =
       process.env.SHOULD_CALL_REAL_API === "1" ||
       process.env.SPECIAL_DEVICE_IPS?.split(",").includes(deviceIp);
@@ -152,7 +158,7 @@ export async function turnOnDevice(
       const credentials = Buffer.from(
         `${process.env.URJ_FSFY_API_USER}:${process.env.URJ_FSFY_API_PWD}`,
       ).toString("base64");
-      apiResponse = await (
+      const rawApiResponse = await (
         await fetch(`${process.env.URJ_FSFY_API}/on/${deviceIp}`, {
           cache: "no-cache",
           headers: {
@@ -160,11 +166,19 @@ export async function turnOnDevice(
           },
         })
       ).json();
+      apiResponse = deviceOnResponseSchema.parse(rawApiResponse);
     } else {
       // 1. Call the simulate API to get dummy data
       const { simulateApiCall } = await import("@/lib/utils");
       const currentDate = new Date().toISOString();
-      apiResponse = await simulateApiCall(deviceIp, true, null, currentDate);
+      const simulatedUsage = await simulateApiCall(
+        deviceIp,
+        true,
+        null,
+        currentDate,
+      );
+
+      apiResponse = { status: 1, ...simulatedUsage };
     }
 
     // 2. Create a transaction to ensure both operations succeed or fail together
@@ -177,7 +191,8 @@ export async function turnOnDevice(
           start_date: new Date(),
           end_date: new Date(), // Same as start_date when device is turned on
           estimated_use_time: estimatedUseTime,
-          consumption: apiResponse.usage.today_energy, // Initial consumption is 0
+          // consumption: apiResponse.usage.today_energy, // Initial consumption is 0
+          consumption: apiResponse.usage.month_energy, // Initial consumption is 0
           charge: 0, // Initial charge is 0
         },
       });
@@ -225,7 +240,7 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
       throw new Error("Device is not currently active or missing usage record");
     }
 
-    let apiResponse: UsageResponse;
+    let apiResponse: DeviceOffResponse;
 
     const shouldCallRealApi =
       process.env.SHOULD_CALL_REAL_API === "1" ||
@@ -236,7 +251,7 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
       const credentials = Buffer.from(
         `${process.env.URJ_FSFY_API_USER}:${process.env.URJ_FSFY_API_PWD}`,
       ).toString("base64");
-      apiResponse = await (
+      const rawApiResponse = await (
         await fetch(`${process.env.URJ_FSFY_API}/off/${deviceIp}`, {
           cache: "no-cache",
           headers: {
@@ -244,15 +259,17 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
           },
         })
       ).json();
+      apiResponse = deviceOffResponseSchema.parse(rawApiResponse);
     } else {
       // Call the simulate API to get dummy data
       const { simulateApiCall } = await import("@/lib/utils");
-      apiResponse = await simulateApiCall(
+      const simulatedUsage = await simulateApiCall(
         deviceIp,
         false,
         activeDevice.usage.start_date.toISOString(),
         new Date().toISOString(),
       );
+      apiResponse = { status: 0, ...simulatedUsage };
     }
 
     // Calculate final consumption and update records in a transaction
@@ -260,7 +277,8 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
       // Calculate final consumption (current - initial)
       const finalConsumption = shouldCallRealApi
         ? roundUpTwoDecimals(
-            Number(apiResponse.usage.today_energy) -
+            // Number(apiResponse.usage.today_energy) -
+            Number(apiResponse.usage.month_energy) -
               Number(activeDevice.usage.consumption),
           )
         : Number(
@@ -268,7 +286,8 @@ export async function turnOffDevice(deviceId: string, deviceIp: string) {
               Math.ceil(
                 Math.abs(
                   // Math.abs is used to ensure the result is positive
-                  Number(apiResponse.usage.today_energy) -
+                  // Number(apiResponse.usage.today_energy) -
+                  Number(apiResponse.usage.month_energy) -
                     Number(activeDevice.usage.consumption),
                 ) * 100,
               ) / 100

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { DeviceUsageResponse } from "./zod/usage";
 
 /**
  * Rounds up a number to 2 decimal places and returns it as a number
@@ -26,13 +27,6 @@ function serialize<T>(data: T): T {
   );
 }
 
-// Define the structure of the usage response
-interface UsageResponse {
-  usage: {
-    today_energy: number; // Energy value in watts
-  };
-}
-
 //TODO:: remove this function once api implemented
 // Define the simulateApiCall function
 /* istanbul ignore next */
@@ -41,12 +35,13 @@ async function simulateApiCall(
   isTurnOn: boolean,
   startTime?: string | null,
   date?: string | null,
-): Promise<UsageResponse> {
+): Promise<DeviceUsageResponse> {
   await new Promise((resolve) => setTimeout(resolve, 200)); // Simulate network delay
 
   if (isTurnOn) {
     const energyValue = getEnergyValueForDate(date);
-    return { usage: { today_energy: energyValue } };
+    // return { usage: { today_energy: energyValue } };
+    return { usage: { month_energy: energyValue } };
   } else {
     if (!startTime) {
       throw new Error("startTime must be provided for turn-off action");
@@ -54,7 +49,8 @@ async function simulateApiCall(
     // Calculate realistic usage value based on startTime
     const duration = Date.now() - new Date(startTime).getTime();
     const calculatedValue = (duration / (1000 * 60 * 60)) * 10; // Example calculation
-    return { usage: { today_energy: calculatedValue } };
+    // return { usage: { today_energy: calculatedValue } };
+    return { usage: { month_energy: calculatedValue } };
   }
 }
 
@@ -245,4 +241,4 @@ export function convertDateTimeLocalToUTC(
 }
 
 //using this syntax for making istanbul ignore next work.
-export { cn, serialize, simulateApiCall, type UsageResponse };
+export { cn, serialize, simulateApiCall };

--- a/src/lib/zod/device.ts
+++ b/src/lib/zod/device.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { deviceUsageResponseSchema } from "./usage";
+
+export const deviceOnResponseSchema = z
+  .object({
+    status: z.literal(1),
+  })
+  .extend(deviceUsageResponseSchema.shape);
+
+export type DeviceOnResponse = z.infer<typeof deviceOnResponseSchema>;
+
+export const deviceOffResponseSchema = z
+  .object({
+    status: z.literal(0),
+  })
+  .extend(deviceUsageResponseSchema.shape);
+
+export type DeviceOffResponse = z.infer<typeof deviceOffResponseSchema>;

--- a/src/lib/zod/usage.ts
+++ b/src/lib/zod/usage.ts
@@ -11,3 +11,11 @@ export const deviceSelectListResponseSchema = z.array(
 export type DeviceSelectionList = z.infer<
   typeof deviceSelectListResponseSchema
 >;
+
+export const deviceUsageResponseSchema = z.object({
+  usage: z.object({
+    month_energy: z.number(),
+  }),
+});
+
+export type DeviceUsageResponse = z.infer<typeof deviceUsageResponseSchema>;


### PR DESCRIPTION
# About
- Addresssing #37 
  - Bug mitigation for #36; 
  
# Changes
- Implemented new Zod schemas and TS types to parse responses when interacting with the device-api to
  - turn on a device - `deviceOnResponseSchema` & type `DeviceOnResponse`
  - turn off a device - `deviceOffResponseSchema` & type `DeviceOffResponse`
- Replaced type `UsageResponse` with `deviceUsageResponseSchema` & type `DeviceUsageResponse`
  - this removes the `today_energy` and adds `month_energy` property to the `usage` object on the above response bodies.